### PR TITLE
limit vararg conversion to only functions with symbol or improper formals

### DIFF
--- a/sibilant/_builtins.lspy
+++ b/sibilant/_builtins.lspy
@@ -23,8 +23,10 @@
    "defmacro"
    (function defmacro (name formals . body)
 	     (doc "Defines a Macro instance in the current module")
+
 	     `(define-global ,name
-		(macro ,(str name) (function ,name ,formals ,@body))))))
+		((lambda (M) (set-attr M _formals ',formals) M)
+		 (macro ,(str name) (function ,name ,formals ,@body)))))))
 
 
 (defmacro defmacrolet (name . body)

--- a/sibilant/_builtins.lspy
+++ b/sibilant/_builtins.lspy
@@ -24,8 +24,9 @@
    (function defmacro (name formals . body)
 	     (doc "Defines a Macro instance in the current module")
 
+	     (define-local proper (proper? formals))
 	     `(define-global ,name
-		((lambda (M) (set-attr M _formals ',formals) M)
+		((lambda (M) (set-attr M _proper ,proper) M)
 		 (macro ,(str name) (function ,name ,formals ,@body)))))))
 
 

--- a/sibilant/compiler/__init__.py
+++ b/sibilant/compiler/__init__.py
@@ -132,6 +132,7 @@ class Macro(Compiled):
 
     def __init__(self, name, macrofn):
         super().__init__(name)
+        self._formals = None
 
 
     def __new__(cls, name, expandfn):
@@ -147,9 +148,13 @@ class Macro(Compiled):
     def compile(self, compiler, source_obj):
         called_by, source = source_obj
 
-        position = compiler.position_of(source_obj)
-        args, kwargs = simple_parameters(source, position)
-        expr = self.expand(*args, **kwargs)
+        if is_proper(self._formals):
+            position = compiler.position_of(source_obj)
+            args, kwargs = simple_parameters(source, position)
+            expr = self.expand(*args, **kwargs)
+
+        else:
+            expr = self.expand(*source.unpack())
 
         # a Macro should always evaluate to some kind of non-None. If
         # all the work of the macro was performed in the environment

--- a/sibilant/compiler/__init__.py
+++ b/sibilant/compiler/__init__.py
@@ -132,7 +132,7 @@ class Macro(Compiled):
 
     def __init__(self, name, macrofn):
         super().__init__(name)
-        self._formals = None
+        self._proper = True
 
 
     def __new__(cls, name, expandfn):
@@ -148,7 +148,7 @@ class Macro(Compiled):
     def compile(self, compiler, source_obj):
         called_by, source = source_obj
 
-        if is_proper(self._formals):
+        if self._proper:
             position = compiler.position_of(source_obj)
             args, kwargs = simple_parameters(source, position)
             expr = self.expand(*args, **kwargs)

--- a/sibilant/compiler/specials.py
+++ b/sibilant/compiler/specials.py
@@ -1,3 +1,4 @@
+
 # This library is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as
 # published by the Free Software Foundation; either version 3 of the
@@ -615,6 +616,7 @@ def _helper_function(code, name, args, body, declared_at=None):
 
     formals = gather_formals(args, code.position_of(args) or declared_at)
     pos, keys, defaults, star, starstar = formals
+    proper = is_proper(args)
 
     argnames = list(map(str, pos))
 
@@ -643,7 +645,8 @@ def _helper_function(code, name, args, body, declared_at=None):
                              varargs=varargs,
                              varkeywords=varkeywords,
                              name=name,
-                             declared_at=declared_at)
+                             declared_at=declared_at,
+                             proper_varargs=proper)
 
     with kid as subc:
         _helper_begin(subc, body)


### PR DESCRIPTION
* only inject the cons conversion step for functions which have improper formals
* only gather_parameters for macro expansion when the formals for the macro are proper. This will allow macros to take flexible keywords as the source to expand
* decorate macros to enable checking for the above at expand time.

Closes #57 