### PR TITLE
macros for eval and compile

### DIFF
--- a/sibilant/_bootstrap_builtins.py
+++ b/sibilant/_bootstrap_builtins.py
@@ -425,6 +425,8 @@ def setup(glbls):
     _op(__import__, "import")
     _op(globals, "globals")
     _op(locals, "locals")
+    _op(compile, "py-compile")
+    _op(eval, "py-eval")
 
     _op(sys.exit, "exit")
 

--- a/sibilant/_builtins.lspy
+++ b/sibilant/_builtins.lspy
@@ -262,12 +262,19 @@
 (defmacro compile (source env: None filename: "<anon>")
   (when (none? env) (setq env '(globals)))
 
-  (let ((io (import "io")))
-    `(let ((src ,source) (sib (import "sibilant.compiler")))
+  `(let ((src ,source) (io (import "io")) (sib (import "sibilant.compiler")))
+     (if (isinstance src (values str io.IOBase))
+	 then: (next (sib.compiler.iter_compile src ,env ,filename))
+	 else: (sib.compiler.compile_expression src ,env ,filename))))
 
-       ,(if (isinstance source (values str io.IOBase))
-	    then: `(next (sib.compiler.iter_compile src ,env ,filename))
-	    else: `(sib.compiler.compile_expression src ,env ,filename)))))
+
+(defmacro eval (source env: None)
+  (when (none? env) (setq env '(globals)))
+
+  `(let ((src ,source) (types (import "types")))
+     (if (isinstance src types.CodeType)
+	 then: (py-eval src ,env)
+	 else: (py-eval (compile src ,env) ,env))))
 
 
 ;;

--- a/sibilant/_builtins.lspy
+++ b/sibilant/_builtins.lspy
@@ -259,5 +259,16 @@
      (type ,(str name) (values ,@bases) flds)))
 
 
+(defmacro compile (source env: None filename: "<anon>")
+  (when (none? env) (setq env '(globals)))
+
+  (let ((io (import "io")))
+    `(let ((src ,source) (sib (import "sibilant.compiler")))
+
+       ,(if (isinstance source (values str io.IOBase))
+	    then: `(next (sib.compiler.iter_compile src ,env ,filename))
+	    else: `(sib.compiler.compile_expression src ,env ,filename)))))
+
+
 ;;
 ;; The end.


### PR DESCRIPTION
* provide the python originals as py-eval and py-compile
* compile will work on strings, streams, and sibilant source objects such as cons pairs, symbols, and self-evaluating types

Closes #80