### PR TITLE
define is scope aware

### DIFF
--- a/examples/sample-project/sibsampl/cli.lspy
+++ b/examples/sample-project/sibsampl/cli.lspy
@@ -18,9 +18,6 @@
 (defimportfrom os.path basename)
 
 
-(defmacrolet var 'define-local)
-
-
 (defun item-slice (value :start None :stop None :step 1)
   (item value (slice start stop step)))
 

--- a/sibilant/_builtins.lspy
+++ b/sibilant/_builtins.lspy
@@ -24,7 +24,7 @@
    (function defmacro (name formals . body)
 	     (doc "Defines a Macro instance in the current module")
 
-	     (define-local proper (proper? formals))
+	     (define proper (proper? formals))
 	     `(define-global ,name
 		((lambda (M) (set-attr M _proper ,proper) M)
 		 (macro ,(str name) (function ,name ,formals ,@body)))))))
@@ -37,11 +37,11 @@
 
 
 (defmacro defun (name params . body)
-  `(define ,name (function ,name ,params ,@body)))
+  `(define-global ,name (function ,name ,params ,@body)))
 
 
 (defmacro defclass (name bases . body)
-  `(define ,name (class ,name ,bases ,@body)))
+  `(define-global ,name (class ,name ,bases ,@body)))
 
 
 ;; === reader macros and atom matchers ===
@@ -104,7 +104,7 @@
 ;; === imports ===
 
 (defmacro defimport (modulename as-name: None)
-  (doc "Import a module and bind it to the global scope")
+  (doc "Import a module and bind it to the current scope")
 
   (unless (symbol? modulename)
     (raise (Exception (% "defimport module name must be a symbol, not %r"
@@ -121,7 +121,7 @@
 
 (defmacro defimportfrom (modulename . &bindings)
   (doc "Import definitions from a module and bind them to the"
-       "global scope")
+       "current scope")
 
   (unless (symbol? modulename)
     (raise (Exception (% "defimportfrom module name must be a symbol, not %r"
@@ -135,13 +135,15 @@
     (while &bindings
       (setq current (car &bindings))
 
-      (setq member (if (pair? current) (first current) current))
-      (setq byname (if (pair? current) (second current) member))
+      ;; todo: use my cooler binding exploder
+      (setq byname (if (pair? current) (first current) member))
+      (setq member (if (pair? current) (second current) current))
 
       (coll.append
-       `(define ,byname (attr (import ,(str modulename) (globals) None
-				      (build-list ,(str member)))
-			      ,member)))
+       `(define ,byname
+	  (attr (import ,(str modulename) (globals) None
+			(build-list ,(str member)))
+		,member)))
 
       (setq &bindings (cdr &bindings)))
 
@@ -150,16 +152,16 @@
 
 ;; === runtime macroexpand ===
 
-(define _sibilant_compiler (attr (import "sibilant.compiler") compiler))
-(define _macroexpand_1 _sibilant_compiler.macroexpand_1)
-(define _macroexpand _sibilant_compiler.macroexpand)
+(defimportfrom sibilant.compiler
+  (macroexpandq-1 macroexpand_1)
+  (macroexpandq macroexpand))
 
 
 (defmacro macroexpand-1 (source)
-  `(_macroexpand_1 (globals) ',source))
+  `(macroexpandq_1 (globals) ',source))
 
 (defmacro macroexpand (source)
-  `(_macroexpand (globals) ',source))
+  `(macroexpandq (globals) ',source))
 
 
 ;; === setf and general variables ===
@@ -209,35 +211,77 @@
 
 ;; === def general targets ===
 
+
 (let ((*gd-targets* (dict))
       (*gd-scopes* (dict)))
-
-  (defun gd-define-target-fn (name fn)
-    (set-item *gd-targets* name fn)
-    None)
 
   (defun gd-define-scope-fn (key fn)
     (set-item *gd-scopes* key fn)
     None)
 
-  (defmacro gd-define-target (name formals . body)
-    `(gd-define-target-fn
-      ,name
-      (lambda ,formals ,@body)))
-
   (defmacro gd-define-scope (name formals . body)
-    `(gd-define-target-fn
-      ,name
+    `(gd-define-scope-fn
+      (keyword ,name)
       (lambda ,formals ,@body)))
 
   (defmacro gd-define-simple-scope (name setter)
     `(gd-define-scope
-      ,name (dest val) `(,',setter ,dest ,val)))
+      ,name (dest val) `(,,setter ,dest ,val)))
+
+  (defun gd-define-target-fn (name fn)
+    (set-item *gd-targets* name fn)
+    None)
+
+  (defmacro gd-define-target (name formals . body)
+    `(gd-define-target-fn
+      (symbol ',name)
+      (lambda ,formals ,@body)))
+
+  (defmacro gd-define-simple-target (name factory)
+    `(gd-define-target ,name (setter source)
+		       (setter (car source) `(,,factory ,@(cdr source)))))
+
+
+  (defmacro def source
+    (let ((scope ':local)
+	  (target None)
+	  (d-scope None)
+	  (d-target None))
+
+      (when (keyword? (car source))
+	(setq scope (car source))
+	(setq source (cdr source)))
+
+      (print *gd-scopes*)
+      (setq d-scope (dict.get *gd-scopes* scope None))
+      (when (none? d-scope)
+	(raise (Exception (% "undefined def scope %r" scope))))
+
+      (setq target (car source))
+      (setq source (cdr source))
+
+      (setq d-target (dict.get *gd-targets* target None))
+      (when (none? d-target)
+	(raise (Exception (% "undefined def target %r" target))))
+
+      (print "scope:" scope)
+      (print "target:" target)
+      (print "source:" source)
+
+      (d-target d-scope source)))
 
   None)
 
 (begin
- (gd-define-simple-scope ':global define-global)
+ (gd-define-simple-scope ':local 'define)
+ (gd-define-simple-scope ':global 'define-global)
+ ;; todo: thread-local
+
+ None)
+
+(begin
+ (gd-define-simple-target function 'function)
+ (gd-define-simple-target classy 'class)
 
  None)
 
@@ -248,13 +292,13 @@
 ;;   (unless (is str (type atom))
 ;;     (raise (Exception (% "what happened in c__r: %r" atom))))
 
-;;   (define-local sb (attr (import "sibilant.builtins") builtins))
-;;   (define-local sd sb.__dict__)
+;;   (define sb (attr (import "sibilant.builtins") builtins))
+;;   (define sd sb.__dict__)
 
-;;   (define-local found (dict.get sd atom None))
+;;   (define found (dict.get sd atom None))
 
 ;;   (when (none? found)
-;;     (define-local calls (reduce (lambda (cell atom-char)
+;;     (define calls (reduce (lambda (cell atom-char)
 ;; 				  (cons (if (eq "a" atom-char) 'car 'cdr)
 ;; 					cell))
 ;; 				(item atom (slice -2 1 -1))
@@ -291,7 +335,7 @@
 (defmacro local (name . dfn)
   (let ((target (first dfn)))
     (cond ((or (eq target 'function) (eq target 'class))
-	   `(define-local ,(second dfn) ,dfn))
+	   `(define ,(second dfn) ,dfn))
 	  (else:
 	   (raise (Exception (% "invalid local definition %" target)))))))
 
@@ -308,9 +352,9 @@
 (defmacro class (name bases . body)
   `(let ((body (lambda (*members*)
 		 (begin ,@body)
-		 *members*)))
+		 *members*))
+	 (flds (dict :__module__ __name__)))
 
-     (define-local flds (dict :__module__ __name__))
      (body flds)
      (set-item flds "__doc__" body.__doc__)
      (type ,(str name) (values ,@bases) flds)))

--- a/sibilant/compiler/specials.py
+++ b/sibilant/compiler/specials.py
@@ -38,6 +38,7 @@ _symbol_set_attr = symbol("set-attr")
 _symbol_setq = symbol("setq")
 _symbol_global = symbol("global")
 _symbol_define = symbol("define")
+_symbol_var = symbol("var")
 _symbol_define_global = symbol("define-global")
 _symbol_defmacro = symbol("defmacro")
 _symbol_quote = symbol("quote")
@@ -1089,13 +1090,19 @@ def _special_define_global(code, source, tc=False):
     return None
 
 
-@special(_symbol_define)
+@special(_symbol_define, _symbol_var)
 def _special_define(code, source, tc=False):
     """
     (define SYM EXPRESSION)
 
     Defines or sets a value in a local context. If EXPRESSION is
     omitted, it defaults to None.
+
+    At the module level, the local context is the same as the global
+    context
+
+    (var SYM EXPRESSION)
+    same as above
     """
 
     called_by, (binding, body) = source

--- a/sibilant/compiler/specials.py
+++ b/sibilant/compiler/specials.py
@@ -39,7 +39,6 @@ _symbol_setq = symbol("setq")
 _symbol_global = symbol("global")
 _symbol_define = symbol("define")
 _symbol_define_global = symbol("define-global")
-_symbol_define_local = symbol("define-local")
 _symbol_defmacro = symbol("defmacro")
 _symbol_quote = symbol("quote")
 _symbol_quasiquote = symbol("quasiquote")
@@ -716,10 +715,10 @@ def _helper_function(code, name, args, body, declared_at=None):
     for expr in defaults:
         code.add_expression(expr)
 
-    kid = code.child_context(args=argnames,
+    kid = code.child_context(name=name,
+                             args=argnames,
                              varargs=varargs,
                              varkeywords=varkeywords,
-                             name=name,
                              declared_at=declared_at,
                              proper_varargs=proper,
                              tco_enabled=tco)
@@ -1065,7 +1064,7 @@ def _special_global(code, source, tc=False):
     return None
 
 
-@special(_symbol_define_global, _symbol_define)
+@special(_symbol_define_global)
 def _special_define_global(code, source, tc=False):
     """
     (define-global SYM EXPRESSION)
@@ -1090,10 +1089,10 @@ def _special_define_global(code, source, tc=False):
     return None
 
 
-@special(_symbol_define_local)
-def _special_define_local(code, source, tc=False):
+@special(_symbol_define)
+def _special_define(code, source, tc=False):
     """
-    (define-local SYM EXPRESSION)
+    (define SYM EXPRESSION)
 
     Defines or sets a value in a local context. If EXPRESSION is
     omitted, it defaults to None.
@@ -1104,10 +1103,14 @@ def _special_define_local(code, source, tc=False):
     _helper_begin(code, body, False)
 
     if not is_symbol(binding):
-        raise code.error("define-local with non-symbol binding", source)
+        raise code.error("define with non-symbol binding", source)
+
+    varname = str(binding)
+
+    code.declare_var(varname)
 
     code.pseudop_position_of(source)
-    code.pseudop_set_local(str(binding))
+    code.pseudop_set_var(varname)
 
     # define expression evaluates to None
     code.pseudop_const(None)

--- a/sibilant/module.py
+++ b/sibilant/module.py
@@ -18,7 +18,7 @@ import types
 from io import IOBase
 from os.path import split
 
-from sibilant.compiler import iter_compile
+from sibilant.compiler import iter_compile, Mode
 from sibilant.parse import source_str, source_stream
 
 
@@ -67,7 +67,8 @@ def exec_module(module, thing, filename=None):
 
     thing.skip_exec()
 
-    for code in iter_compile(thing, glbls, filename=filename):
+    for code in iter_compile(thing, glbls,
+                             filename=filename, mode=Mode.MODULE):
         eval(code, glbls)
         consumed.append(code)
 

--- a/sibilant/repl.py
+++ b/sibilant/repl.py
@@ -26,7 +26,7 @@ import sibilant.builtins
 
 from traceback import format_exception, format_exception_only
 
-from sibilant.compiler import iter_compile
+from sibilant.compiler import iter_compile, Mode
 from sibilant.parse import default_reader
 
 
@@ -60,6 +60,7 @@ def repl(stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr,
     for line in stdin:
         try:
             for code in iter_compile(line, env,
+                                     mode=Mode.MODULE,
                                      filename="<repl>",
                                      reader=reader):
                 if code:

--- a/tests/compiler/specials.py
+++ b/tests/compiler/specials.py
@@ -454,10 +454,10 @@ class CompilerSpecials(TestCase):
         self.assertEqual(stmt(), 190)
 
 
-    def test_define_local(self):
+    def test_define(self):
         src = """
         (begin
-          (define-local tacos 100)
+          (define tacos 100)
           tacos)
         """
         stmt, env = compile_expr(src)
@@ -466,7 +466,7 @@ class CompilerSpecials(TestCase):
 
         src = """
         (begin
-          (define-local tacos 100)
+          (define tacos 100)
           tacos)
         """
         stmt, env = compile_expr(src, tacos=5)
@@ -475,8 +475,8 @@ class CompilerSpecials(TestCase):
 
         src = """
         (let ((beer 999))
-          (define-local tacos beer)
-          (define-local nachos 100)
+          (define tacos beer)
+          (define nachos 100)
           (+ nachos tacos))
         """
         stmt, env = compile_expr(src, tacos=5)


### PR DESCRIPTION
* define in the module scope is a global define
* define otherwise is a local define
* define-global remains for forcing a global define
* var added as alias for define
* CodeSpace gained a mode parameter, to differentiate module vs. expression
* updated sample code
* created def, a generic form of define which will allow new binding functions to add scopes and targets at runtime

Closes #21