### PR TITLE
class macro now uses locals to populate members. remove method macro.

### DIFF
--- a/examples/reader-macro.lspy
+++ b/examples/reader-macro.lspy
@@ -23,9 +23,9 @@
 
 ;; a contrived dollars class, based on the float type.
 (defclass dollars (float)
-  (method __str__ (self)
+  (def function __str__ (self)
 	  (% "$%0.02f" self))
-  (method __repr__ (self)
+  (def function __repr__ (self)
 	  (% "(dollars %0.02f)" self)))
 
 

--- a/examples/reader-macro.lspy
+++ b/examples/reader-macro.lspy
@@ -45,7 +45,7 @@
 ;; $100 to (dollars 100) happens at read time, which is before compile
 ;; time, and also before run time.
 (defun example ()
-  (define-local X $100)
+  (var X $100)
   (print-example (type X))
   (print-example (repr X))
   (print-example (str X))

--- a/sibilant/_bootstrap_builtins.py
+++ b/sibilant/_bootstrap_builtins.py
@@ -65,8 +65,13 @@ def setup(glbls):
         __str__ = __repr__
 
 
-    def _op(opf, name=None, rename=False):
+    def _op(opf, name=None, rename=False, tco_disable=False):
         name = name if name else opf.__name__
+
+        if tco_disable:
+            if not isinstance(opf, partial):
+                opf = wraps(opf)(builtin_partial(opf))
+            opf = tco.tco_disable(opf)
 
         if rename:
             opf.__name__ = name
@@ -423,12 +428,12 @@ def setup(glbls):
     _val(object, "object")
 
     _op(__import__, "import")
-    _op(globals, "globals")
-    _op(locals, "locals")
+    _op(globals, "globals", tco_disable=True)
+    _op(locals, "locals", tco_disable=True)
     _op(compile, "py-compile")
     _op(eval, "py-eval")
 
-    _op(sys.exit, "exit")
+    _op(sys.exit, "exit", tco_disable=True)
 
 
     # done with setup

--- a/sibilant/_bootstrap_builtins.py
+++ b/sibilant/_bootstrap_builtins.py
@@ -162,6 +162,7 @@ def setup(glbls):
 
     _op(tco.trampoline, "trampoline")
     _op(tco.tailcall, "tailcall")
+    _op(tco.tco_disable, "tco-disable")
 
 
     # === some python builtin types ===

--- a/sibilant/_builtins.lspy
+++ b/sibilant/_builtins.lspy
@@ -276,7 +276,7 @@
 
 (begin
  (gd-define-simple-target function 'function)
- (gd-define-simple-target classy 'class)
+ (gd-define-simple-target class 'class)
 
  None)
 

--- a/sibilant/_builtins.lspy
+++ b/sibilant/_builtins.lspy
@@ -239,8 +239,8 @@
 
   (defmacro gd-define-simple-target (name factory)
     `(gd-define-target ,name (setter source)
-		       (setter (car source) `(,,factory ,@(cdr source)))))
-
+		       (setter (car source)
+			       `(,,factory ,@source))))
 
   (defmacro def source
     (let ((scope ':local)
@@ -263,10 +263,6 @@
       (setq d-target (dict.get *gd-targets* target None))
       (when (none? d-target)
 	(raise (Exception (% "undefined def target %r" target))))
-
-      (print "scope:" scope)
-      (print "target:" target)
-      (print "source:" source)
 
       (d-target d-scope source)))
 
@@ -342,22 +338,11 @@
 
 ;; === python object system classes ==
 
-(defmacro method (name params . body)
-  `(let ((method (function ,name ,params ,@body))
-	 (name ,(str name)))
-     (set-item *members* name method)
-     None))
-
 
 (defmacro class (name bases . body)
-  `(let ((body (lambda (*members*)
-		 (begin ,@body)
-		 *members*))
-	 (flds (dict :__module__ __name__)))
-
-     (body flds)
-     (set-item flds "__doc__" body.__doc__)
-     (type ,(str name) (values ,@bases) flds)))
+  `(type ,(str name) (values ,@bases)
+	 (let ((fields (lambda (__module__) (begin ,@body) (locals))))
+	   (fields __name__))))
 
 
 (defmacro compile (source env: None filename: "<anon>")

--- a/sibilant/_builtins.lspy
+++ b/sibilant/_builtins.lspy
@@ -252,7 +252,6 @@
 	(setq scope (car source))
 	(setq source (cdr source)))
 
-      (print *gd-scopes*)
       (setq d-scope (dict.get *gd-scopes* scope None))
       (when (none? d-scope)
 	(raise (Exception (% "undefined def scope %r" scope))))

--- a/sibilant/compiler/tco.py
+++ b/sibilant/compiler/tco.py
@@ -14,7 +14,7 @@
 
 
 __all__ = (
-    "trampoline", "tailcall",
+    "trampoline", "tailcall", "tco_disable",
 )
 
 
@@ -47,6 +47,10 @@ def setup():
         raised, the trampoline will return that result.
         """
 
+        skip = _ga(fun, "_tco_disable", False)
+        if skip:
+            return fun
+
         # if fun is already a wrapped tailcall, or it's a wrapped
         # trampoline, we'll unwrap it first.
         fun = _ga(fun, "_tco_original", fun)
@@ -63,6 +67,10 @@ def setup():
 
 
     def tailcall(fun):
+        skip = _ga(fun, "_tco_disable", False)
+        if skip:
+            return fun
+
         # if fun is already a wrapped tailcall, or it's a wrapped
         # trampoline, we'll unwrap it first.
         fun = _ga(fun, "_tco_original", fun)
@@ -72,10 +80,25 @@ def setup():
 
         return tco_bounce
 
-    return trampoline, tailcall
+
+    def tco_disable(fun):
+        """
+        Decorator to instruct the tailcall optimization to never tailcall
+        or wrap as a trampoline the decorated function.
+        """
+
+        # if fun is already a wrapped tailcall, or it's a wrapped
+        # trampoline, we'll unwrap it first.
+        fun = _ga(fun, "_tco_original", fun)
+
+        fun._tco_disable = True
+        return fun
 
 
-trampoline, tailcall = setup()
+    return trampoline, tailcall, tco_disable
+
+
+trampoline, tailcall, tco_disable = setup()
 del setup
 
 

--- a/sibilant/compiler/tco.py
+++ b/sibilant/compiler/tco.py
@@ -34,7 +34,7 @@ def setup():
         # invocation of partial has very very low overhead, so we'll
         # just subclass it and inject a single slot for marking up the
         # original function.
-        __slots__ = ("_tco_original", )
+        pass
 
 
     def trampoline(fun):
@@ -47,9 +47,12 @@ def setup():
         raised, the trampoline will return that result.
         """
 
-        skip = _ga(fun, "_tco_disable", False)
-        if skip:
-            return fun
+        # note we don't check for _tco_disable here, because by the
+        # time we get this far, the function has been compiled
+        # expecting to have a trampoline under it, and it will return
+        # TailCall objects. Without the trampoline, those would end up
+        # in the normal return flow, and would break a bunch of
+        # things.
 
         # if fun is already a wrapped tailcall, or it's a wrapped
         # trampoline, we'll unwrap it first.
@@ -67,8 +70,7 @@ def setup():
 
 
     def tailcall(fun):
-        skip = _ga(fun, "_tco_disable", False)
-        if skip:
+        if _ga(fun, "_tco_disable", False):
             return fun
 
         # if fun is already a wrapped tailcall, or it's a wrapped
@@ -84,14 +86,11 @@ def setup():
     def tco_disable(fun):
         """
         Decorator to instruct the tailcall optimization to never tailcall
-        or wrap as a trampoline the decorated function.
+        bounce the given function
         """
 
-        # if fun is already a wrapped tailcall, or it's a wrapped
-        # trampoline, we'll unwrap it first.
-        fun = _ga(fun, "_tco_original", fun)
-
         fun._tco_disable = True
+
         return fun
 
 

--- a/tests/sibilant/__init__.py
+++ b/tests/sibilant/__init__.py
@@ -1,0 +1,22 @@
+# This library is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see
+# <http://www.gnu.org/licenses/>.
+
+
+import sibilant.importer
+
+from tests.sibilant.builtins import *
+
+
+#
+# The end.

--- a/tests/sibilant/builtins.lspy
+++ b/tests/sibilant/builtins.lspy
@@ -1,0 +1,39 @@
+;; This library is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU Lesser General Public License as
+;; published by the Free Software Foundation; either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This library is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; Lesser General Public License for more details.
+;;
+;; You should have received a copy of the GNU Lesser General Public
+;; License along with this library; if not, see
+;; <http://www.gnu.org/licenses/>.
+
+
+(defimport unittest)
+
+
+(def class DefclassTest (unittest.TestCase)
+
+  (def function test_def_class (self)
+
+       (def class simple (object)
+	    (def function __init__ (self foo: 100)
+		 (setf self.foo foo))
+
+	    (def function get-foo (self) self.foo))
+
+       (var sinst (simple))
+
+       (self.assertIs (type simple) type)
+       (self.assertIs (type sinst) simple)
+       (self.assertEqual sinst.foo (sinst.get-foo))
+
+       None))
+
+
+;;
+;; The end.


### PR DESCRIPTION
* method macro removed
* class macro uses locals call
* added tco_disable to prevent TCO trampoline bounces on locals and globals
* added a sibilant-native unittest
* fixed def class (was def classy)

Closes #84