### PR TITLE
implement compile-to-file

### DIFF
--- a/ideas/todo-time
+++ b/ideas/todo-time
@@ -1,0 +1,45 @@
+
+
+- init time
+  - create module
+  - setup globals
+  - setup builtins
+  - create parser
+  - bind parser to module
+  - create compiler
+  - bind compiler to module
+
+
+- loader iteratively
+  - parse time
+  - compile time
+  - run time
+
+
+- parse time
+  - obtain parser from module
+  - read an expression
+  - handoff expression to loader
+
+- compile time
+  - with expression from parser
+  - obtain compiler from module
+  - pass expression to compiler
+  - handoff code obj to loader
+
+- run time
+  - with code obj from compiler
+  - eval code in environment (side-effects galore!)
+  - handoff result to loader
+
+
+- when loading a pre-compiled module
+  - init time
+  - loader iteratively
+    - bypass parse time
+    - bypass compile time
+    - run time
+
+
+#
+# The end.

--- a/sibilant/_builtins.lspy
+++ b/sibilant/_builtins.lspy
@@ -46,26 +46,23 @@
 
 ;; === reader macros and atom matchers ===
 
+(defmacro _reader_macro (sym attrsym)
+  `(defmacro ,sym args
+     `(try
+       (unless (none? __reader__)
+	 ((attr __reader__ ,',attrsym) ,@args))
+       ((ne NameError) None))))
 
-(defmacrolet set-event-macro `__reader__.set_event_macro)
-
-(defmacrolet get-event-macro `__reader__.get_event_macro)
-
-(defmacrolet clear-event-macro `__reader__.clear_event_macro)
-
-(defmacrolet temp-event-macro `__reader__.temporary_event_macro)
-
-(defmacrolet set-macro-character `__reader__.set_macro_character)
-
-(defmacrolet temp-macro-character `__reader__.temporary_macro_character)
-
-(defmacrolet set-atom-pattern `__reader__.set_atom_pattern)
-
-(defmacrolet get-atom-pattern `__reader__.get_atom_pattern)
-
-(defmacrolet clear-atom-pattern `__reader__.clear_atom_pattern)
-
-(defmacrolet set-atom-regex `__reader__.set_atom_regex)
+(_reader_macro set-event-macro set_event_macro)
+(_reader_macro get-event-macro get_event_macro)
+(_reader_macro clear-event-macro clear_event_macro)
+(_reader_macro temp-event-macro temp_event_macro)
+(_reader_macro set-macro-character set_macro_character)
+(_reader_macro temp-macro-character temp_macro_character)
+(_reader_macro set-atom-pattern set_atom_pattern)
+(_reader_macro get-atom-pattern get_atom_pattern)
+(_reader_macro clear-atom-pattern clear_atom_pattern)
+(_reader_macro set-atom-regex set_atom_regex)
 
 
 ;; === conditionals ===

--- a/sibilant/builtins.py
+++ b/sibilant/builtins.py
@@ -26,7 +26,7 @@ def _setup():
     import sys
     from os.path import join, dirname
     from pkgutil import get_data
-    from .module import create_module
+    from .module import load_module
 
     # because the sibilant.importlib functions will attempt to use
     # this module, we can't rely on them to in-turn load us. Thus for
@@ -43,9 +43,9 @@ def _setup():
 
     src = get_data(__name__, "_builtins.lspy").decode("utf8")
     filename = join(dirname(__file__), "_builtins.lspy")
-    builtins = create_module("sibilant._builtins", src,
-                             builtins=bootstrap,
-                             filename=filename)
+    builtins = load_module("sibilant._builtins", src,
+                           builtins=bootstrap,
+                           filename=filename)
 
     sys.modules["sibilant._builtins"] = builtins
     sys.modules["sibilant"]._builtins = builtins

--- a/sibilant/importlib.py
+++ b/sibilant/importlib.py
@@ -28,11 +28,9 @@ from importlib.abc import FileLoader
 from importlib.machinery import FileFinder, PathFinder
 
 from os import getcwd
-from os.path import basename, getmtime, getsize
+from os.path import basename
 
-from sibilant.module import (
-    prep_module, exec_module, init_module, marshal_module,
-)
+from sibilant.module import prep_module, exec_module
 
 
 # we're going to pre-import this
@@ -156,20 +154,6 @@ def temporary_install():
 def import_module(name, globals_=None, locals_=None, fromlist=0, level=0):
     with temporary_install():
         return __import__(name, globals_, locals_, fromlist, level)
-
-
-def compile_to_file(name, source_file, dest_file):
-    mtime = getmtime(source_file)
-    source_size = getsize(source_file)
-
-    mod = init_module(name, builtins=sibilant.builtins, filename=source_file)
-
-    with open(source_file, "rt") as fin:
-        bytecode = marshal_module(mod, fin, filename=source_file,
-                                  mtime=mtime, source_size=source_size)
-
-    with open(dest_file, "wb") as fout:
-        fout.write(bytecode)
 
 
 #

--- a/sibilant/module.py
+++ b/sibilant/module.py
@@ -13,25 +13,27 @@
 # <http://www.gnu.org/licenses/>.
 
 
+import dis
 import types
 
 from io import IOBase
 from os.path import split
 
-from sibilant.compiler import iter_compile, Mode
+from sibilant.compiler import Mode, iter_compile, code_space_for_version
 from sibilant.parse import source_str, source_stream
 
 
 __all__ = (
-    "create_module", "prep_module", "exec_module"
+    "init_module", "load_module", "prep_module", "exec_module",
+    "marshal_module",
 )
 
 
-def create_module(name, thing, builtins=None, defaults=None, filename=None):
+def init_module(name, builtins=None, defaults=None, filename=None):
     mod = types.ModuleType(name)
 
-    prep_module(mod, builtins=builtins, defaults=defaults, filename=filename)
-    exec_module(mod, thing, filename=filename)
+    prep_module(mod, builtins=builtins,
+                defaults=defaults, filename=filename)
 
     return mod
 
@@ -54,9 +56,18 @@ def prep_module(module, builtins=None, defaults=None, filename=None):
     return None
 
 
-def exec_module(module, thing, filename=None):
+def load_module(name, thing, builtins=None, defaults=None, filename=None):
 
-    consumed = []
+    mod = init_module(name, builtins=builtins,
+                      defaults=defaults, filename=filename)
+
+    exec_module(mod, thing, filename=filename)
+
+    return mod
+
+
+def iter_compile_module(module, thing, filename=None):
+
     glbls = module.__dict__
 
     if isinstance(thing, str):
@@ -67,17 +78,74 @@ def exec_module(module, thing, filename=None):
 
     thing.skip_exec()
 
-    for code in iter_compile(thing, glbls,
-                             filename=filename, mode=Mode.MODULE):
+    return iter_compile(thing, glbls, filename=filename, mode=Mode.MODULE)
+
+
+def exec_module(module, thing, filename=None):
+
+    glbls = module.__dict__
+
+    for code in iter_compile_module(module, thing, filename):
         eval(code, glbls)
-        consumed.append(code)
 
     return None
 
 
-# TODO
-# def py_compile_module(module, outfile):
-#     _code_to_bytecode(module.__code__)
+def exec_marshal_module(glbls, code_objs):
+    builtins = __import__("sibilant.builtins").builtins
+    glbls["__builtins__"] = builtins
+
+    for code in code_objs:
+        eval(code, glbls)
+
+    return None
+
+
+def marshal_module(module, thing, filename=None, mtime=0, source_size=0):
+    from importlib._bootstrap_external import _code_to_bytecode
+
+    glbls = module.__dict__
+    collect = []
+
+    for code in iter_compile_module(module, thing, filename):
+        eval(code, glbls)
+        collect.append(code)
+
+    factory = code_space_for_version()
+    codespace = factory(filename=filename, mode=Mode.MODULE)
+
+    # we can't just have the code object in the file, because we
+    # actually have multiple code objects -- one for each top-level
+    # compiled expression. We also need to swap out builtins, which
+    # isn't as easy as just putting it in globals, since python will
+    # optimize away the builtins lookup if globals is the same between
+    # two frame (ie. it won't check for new __builtins__ since the
+    # globals is the same as the parent). So we cheat. We create a
+    # stub code object which simply invokes the exec_marshal_module
+    # function with the code objects, which are marshalled as a const
+    # tuple.
+
+    # we could have made this easier by making a custom loader for
+    # .lspyc files -- but I'd prefer to be able to just reuse the
+    # existing python loader for .pyc
+
+    with codespace.activate(glbls):
+        codespace.pseudop_get_var("__import__")
+        codespace.pseudop_const("sibilant.module")
+        codespace.pseudop_call(1)
+        codespace.pseudop_get_attr("module")
+        codespace.pseudop_get_attr("exec_marshal_module")
+        codespace.pseudop_get_var("globals")
+        codespace.pseudop_call(0)
+        codespace.pseudop_const(tuple(collect))
+        codespace.pseudop_call(2)
+        codespace.pseudop_pop()
+        codespace.pseudop_return_none()
+
+        code = codespace.complete()
+        dis.dis(code)
+
+    return _code_to_bytecode(code, mtime, source_size)
 
 
 #

--- a/tests/module.py
+++ b/tests/module.py
@@ -24,7 +24,7 @@ license: LGPL v.3
 from unittest import TestCase
 
 from sibilant import car, cdr, cons, nil, symbol
-from sibilant.module import create_module
+from sibilant.module import load_module
 
 
 def getter_setter(value):
@@ -67,8 +67,8 @@ class ModuleTest(TestCase):
         getter, setter = getter_setter(None)
 
         defaults = {"set_result": setter}
-        test_module = create_module("test_module", mod_source_1,
-                                    defaults=defaults)
+        test_module = load_module("test_module", mod_source_1,
+                                  defaults=defaults)
 
         # the last action of the module is to call set_result, and
         # getter can show us what was passed there.


### PR DESCRIPTION
* added a compile_to_file function to sibilant.module
* added a -C option to the sibilant CLI which compiles the specified source to a .pyc file
* tweaked some read-time calls to not presume that __reader__ is always present (since it isn't when the module is pre-compiled)
* thought about people I wanted to forget, so had two mimosas and went somewhere else
* had more ideas to clean up the parse/compile/run time stages, but will implement those separately. For now there's a new file in ideas documenting it
* verified thay Python will load these .pyc files without complaint, and without needing the sibilant source importer enabled.

Closes #8