### PR TITLE
Module Parse, Compile, and Runtime cleanup

### DIFF
--- a/sibilant/_builtins.lspy
+++ b/sibilant/_builtins.lspy
@@ -53,6 +53,7 @@
 	 ((attr __reader__ ,',attrsym) ,@args))
        ((ne NameError) None))))
 
+(_reader_macro read read)
 (_reader_macro set-event-macro set_event_macro)
 (_reader_macro get-event-macro get_event_macro)
 (_reader_macro clear-event-macro clear_event_macro)

--- a/sibilant/builtins.py
+++ b/sibilant/builtins.py
@@ -26,7 +26,9 @@ def _setup():
     import sys
     from os.path import join, dirname
     from pkgutil import get_data
-    from .module import load_module
+
+    from .module import new_module, init_module, load_module
+    from .parse import source_str
 
     # because the sibilant.importlib functions will attempt to use
     # this module, we can't rely on them to in-turn load us. Thus for
@@ -43,12 +45,13 @@ def _setup():
 
     src = get_data(__name__, "_builtins.lspy").decode("utf8")
     filename = join(dirname(__file__), "_builtins.lspy")
-    builtins = load_module("sibilant._builtins", src,
-                           builtins=bootstrap,
-                           filename=filename)
 
-    sys.modules["sibilant._builtins"] = builtins
+    builtins = new_module("sibilant._builtins")
+    init_module(builtins, source_str(src), bootstrap, filename=filename)
+    load_module(builtins)
+
     sys.modules["sibilant"]._builtins = builtins
+    sys.modules["sibilant._builtins"] = builtins
 
     glbls = globals()
     _all = set()

--- a/sibilant/cli.py
+++ b/sibilant/cli.py
@@ -27,8 +27,9 @@ from appdirs import AppDirs
 from argparse import ArgumentParser
 from os.path import basename, join
 
-from .repl import basic_env, repl
-from .module import load_module, compile_to_file
+from .module import new_module, init_module, load_module, compile_to_file
+from .parse import source_open
+from .repl import repl
 
 
 _APPDIR = AppDirs("sibilant")
@@ -78,17 +79,20 @@ def cli(options):
 
     filename = options.filename
 
+    mod = new_module("__main__")
+
     if filename:
-        with open(filename, "rt") as fd:
-            mod = load_module("__main__", fd, filename=filename)
+        with source_open(filename) as source:
+            init_module(mod, source, None)
+            load_module(mod)
 
         if options.interactive:
             # probably not the best way to implement this, but it'll
             # do for now, eh?
-            repl(env=mod.__dict__)
+            repl(mod)
 
     else:
-        repl(env=basic_env(__name__="__main__", __file__=None))
+        repl(mod)
 
 
 def cli_option_parser(args):

--- a/sibilant/importlib.py
+++ b/sibilant/importlib.py
@@ -28,9 +28,9 @@ from importlib.abc import FileLoader
 from importlib.machinery import FileFinder, PathFinder
 
 from os import getcwd
-from os.path import basename
 
-from sibilant.module import prep_module, exec_module
+from .module import init_module, load_module
+from .parse import source_str
 
 
 # we're going to pre-import this
@@ -97,24 +97,26 @@ class SibilantSourceFileLoader(FileLoader):
 
 
     def create_module(self, spec):
+        # return None to let the Python system allocate its own
+        # preferred module type
         return None
 
 
     def get_source(self, fullname):
-        # return self.get_data(self.get_filename(fullname)).decode("utf8")
+        # with open(self.get_filename(fullname), "rt") as sf:
+        #    data = sf.read()
+        # return data
 
-        with open(self.get_filename(fullname), "rt") as sf:
-            data = sf.read()
-        return data
+        return self.get_data(self.get_filename(fullname)).decode("utf8")
 
 
     def exec_module(self, module):
         name = module.__name__
-        source = self.get_source(name)
-        filename = basename(self.get_filename(name))
+        source_stream = source_str(self.get_source(name))
+        filename = self.get_filename(name)
 
-        prep_module(module)
-        exec_module(module, source, filename=filename)
+        init_module(module, source_stream, None, filename=filename)
+        load_module(module)
 
 
 # go ahead and setup the _path_hooks in advance. Even if we don't run

--- a/sibilant/module.py
+++ b/sibilant/module.py
@@ -13,102 +13,246 @@
 # <http://www.gnu.org/licenses/>.
 
 
-import types
-
-from io import IOBase
+from functools import partial
 from os.path import split, getmtime, getsize
+from types import ModuleType
 
-from sibilant.compiler import Mode, iter_compile, code_space_for_version
-from sibilant.parse import source_str, source_stream
+from sibilant.compiler import Mode, code_space_for_version
+from sibilant.parse import default_reader, source_open, source_str
 
 
 __all__ = (
-    "init_module", "load_module", "prep_module", "exec_module",
-    "marshal_module", "exec_marshal_module", "compile_to_file",
+    "new_module", "fake_module_from_env",
+    "init_module", "load_module", "iter_load_module", "load_module_1",
+    "parse_time", "compile_time", "hook_compile_time",
+    "run_time", "partial_run_time",
+    "exec_marshal_module", "marshal_wrapper", "compile_to_file",
 )
 
 
-def init_module(name, builtins=None, defaults=None, filename=None):
-    mod = types.ModuleType(name)
-
-    prep_module(mod, builtins=builtins,
-                defaults=defaults, filename=filename)
-
-    return mod
+def new_module(name):
+    return ModuleType(name)
 
 
-def prep_module(module, builtins=None, defaults=None, filename=None):
-    glbls = module.__dict__
+class FakeModule():
+    pass
+
+
+def fake_module_from_env(env):
+    module = FakeModule()
+    module.__dict__ = env
+    return module
+
+
+def init_module(module, source_stream, builtins,
+                filename=None, defaults=None,
+                reader=None, compiler=None, compiler_factory=None,
+                compiler_factory_params=None,
+                evaluator=None):
+
+    if defaults:
+        module.__dict__.update(defaults)
 
     if filename:
         module.__file__ = filename
         module.__path__ = split(filename)
 
-    if defaults:
-        glbls.update(defaults)
+    module.__stream__ = source_stream
 
     if builtins is None:
         builtins = __import__("sibilant.builtins").builtins
+    module.__builtins__ = builtins
 
-    glbls["__builtins__"] = builtins
+    if reader:
+        module.__reader__ = reader
 
-    return None
+    if compiler:
+        module.__compiler__ = compiler
 
+    if compiler_factory:
+        module.__compiler_factory__ = compiler_factory
 
-def load_module(name, thing, builtins=None, defaults=None, filename=None):
+    if compiler_factory_params:
+        module.__compiler_factory_params__ = compiler_factory_params
 
-    mod = init_module(name, builtins=builtins,
-                      defaults=defaults, filename=filename)
+    if evaluator:
+        module.__evaluator__ = evaluator
 
-    exec_module(mod, thing, filename=filename)
-
-    return mod
-
-
-def iter_compile_module(module, thing, filename=None):
-
-    glbls = module.__dict__
-
-    if isinstance(thing, str):
-        thing = source_str(thing, filename)
-
-    elif isinstance(thing, IOBase):
-        thing = source_stream(thing, filename)
-
-    thing.skip_exec()
-
-    return iter_compile(thing, glbls, filename=filename, mode=Mode.MODULE)
+    return module
 
 
-def exec_module(module, thing, filename=None):
+def get_module_reader(module):
+    try:
+        reader = module.__reader__
+    except:
+        reader = default_reader
+        module.__reader__ = reader
 
-    glbls = module.__dict__
+    return reader
 
-    for code in iter_compile_module(module, thing, filename):
-        eval(code, glbls)
 
-    return None
+def get_module_stream(module):
+    try:
+        stream = module.__stream__
+    except:
+        stream = source_str("")
+        module.__stream__ = stream
+
+    return stream
+
+
+def parse_time(module):
+    reader = get_module_reader(module)
+    stream = get_module_stream(module)
+
+    return reader.read(stream)
+
+
+def get_module_compiler_factory_params(module):
+    try:
+        params = module.__compiler_factory_params__
+
+    except:
+        params = {
+            "name": getattr(module, "__name__", None),
+            "filename": getattr(module, "__file__", None),
+            "mode": Mode.MODULE,
+        }
+        module.__compiler_factory_params__ = params
+
+    return params
+
+
+def get_module_compiler_factory(module):
+    try:
+        factory = module.__compiler_factory__
+
+    except:
+        factory = code_space_for_version()
+        module.__compiler_factory__ = factory
+
+    return factory
+
+
+def get_module_compiler(module):
+    try:
+        compiler = module.__compiler__
+
+    except:
+        factory = get_module_compiler_factory(module)
+        params = get_module_compiler_factory_params(module)
+        compiler = factory(**params)
+        module.__compiler__ = compiler
+
+    return compiler
+
+
+def compile_time(module, source_expr):
+    """
+    Performs compile-time operations on source_expr in a module
+    """
+
+    compiler = get_module_compiler(module)
+    module_globals = module.__dict__
+    with compiler.activate(module_globals):
+        compiler.add_expression_with_return(source_expr)
+        code_obj = compiler.complete()
+
+    return code_obj
+
+
+def hook_compile_time(hook_fn, compile_time=compile_time):
+    """
+    Creates a compile_time wrapper which will call hook_fn with the
+    given module, source_expr, and the code_obj result of
+    compile_time. Can be used to accumulate code_obj without
+    re-implementing the entire parse, compile, run loop of load_module
+    """
+
+    def compile_time_with_hook(module, source_expr):
+        code_obj = compile_time(module, source_expr)
+        hook_fn(module, source_expr, code_obj)
+        return code_obj
+
+    return compile_time_with_hook
+
+
+def get_module_evaluator(module):
+    try:
+        evaluator = module.__evaluator__
+
+    except:
+        mod_globals = module.__dict__
+
+        def evaluator(code):
+            return eval(code, mod_globals)
+
+        module.__evaluator__ = evaluator
+
+    return evaluator
+
+
+def run_time(module, code_obj):
+    evaluator = get_module_evaluator(module)
+    return evaluator(code_obj)
+
+
+def partial_run_time(module, code_obj):
+    evaluator = get_module_evaluator(module)
+    return partial(evaluator, code_obj)
+
+
+def load_module(module, parse_time=parse_time,
+                compile_time=compile_time, run_time=run_time):
+
+    try:
+        while True:
+            load_module_1(module, parse_time, compile_time, run_time)
+
+    except StopIteration:
+        pass
+
+
+def iter_load_module(module, parse_time=parse_time,
+                     compile_time=compile_time, run_time=run_time):
+
+    while True:
+        yield load_module_1(module, parse_time, compile_time, run_time)
+
+
+def load_module_1(module, parse_time=parse_time,
+                  compile_time=compile_time, run_time=run_time):
+
+    source_expr = parse_time(module)
+
+    if source_expr is None:
+        raise StopIteration
+
+    else:
+        code_obj = compile_time(module, source_expr)
+        return run_time(module, code_obj)
 
 
 def exec_marshal_module(glbls, code_objs):
-    builtins = __import__("sibilant.builtins").builtins
-    glbls["__builtins__"] = builtins
+    """
+    Invoked during loading of modules expored via marshal_wrapper
+    """
 
-    for code in code_objs:
-        eval(code, glbls)
+    mod = fake_module_from_env(glbls)
+    init_module(mod, None, None)
+
+    # skips the read time and compile time stages of import, just
+    # performs run time for every compiled expression to set up the
+    # module
+
+    for code_obj in code_objs:
+        run_time(mod, code_obj)
 
     return None
 
 
-def marshal_module(module, thing, filename=None, mtime=0, source_size=0):
+def marshal_wrapper(code_objs, filename=None, mtime=0, source_size=0):
     from importlib._bootstrap_external import _code_to_bytecode
-
-    glbls = module.__dict__
-    collect = []
-
-    for code in iter_compile_module(module, thing, filename):
-        eval(code, glbls)
-        collect.append(code)
 
     factory = code_space_for_version()
     codespace = factory(filename=filename, mode=Mode.MODULE)
@@ -128,7 +272,7 @@ def marshal_module(module, thing, filename=None, mtime=0, source_size=0):
     # .lspyc files -- but I'd prefer to be able to just reuse the
     # existing python loader for .pyc
 
-    with codespace.activate(glbls):
+    with codespace.activate({}):
         codespace.pseudop_get_var("__import__")
         codespace.pseudop_const("sibilant.module")
         codespace.pseudop_call(1)
@@ -136,10 +280,9 @@ def marshal_module(module, thing, filename=None, mtime=0, source_size=0):
         codespace.pseudop_get_attr("exec_marshal_module")
         codespace.pseudop_get_var("globals")
         codespace.pseudop_call(0)
-        codespace.pseudop_const(tuple(collect))
+        codespace.pseudop_const(tuple(code_objs))
         codespace.pseudop_call(2)
-        codespace.pseudop_pop()
-        codespace.pseudop_return_none()
+        codespace.pseudop_return()
 
         code = codespace.complete()
 
@@ -150,14 +293,48 @@ def compile_to_file(name, source_file, dest_file):
     mtime = getmtime(source_file)
     source_size = getsize(source_file)
 
-    mod = init_module(name, filename=source_file)
+    code_objs = []
 
-    with open(source_file, "rt") as fin:
-        bytecode = marshal_module(mod, fin, filename=source_file,
-                                  mtime=mtime, source_size=source_size)
+    def accumulate(_mod, _sexpr, code):
+        code_objs.append(code)
 
-    with open(dest_file, "wb") as fout:
-        fout.write(bytecode)
+    with source_open(source_file) as source_stream:
+        mod = new_module(name)
+        init_module(mod, source_stream, None, filename=source_file)
+        load_module(mod, compile_time=hook_compile_time(accumulate))
+
+    bytecode = marshal_wrapper(code_objs, filename=source_file,
+                               mtime=mtime, source_size=source_size)
+
+    with open(dest_file, "wb") as dest_stream:
+        dest_stream.write(bytecode)
+
+
+# ;; async variations
+
+async def async_parse_time(module):
+    reader = get_module_reader(module)
+    stream = get_module_stream(module)
+
+    print(" == async_parse_time ==", "calling reader.read")
+    r = reader.read(stream)
+    print(" == async_parse_time ==", r)
+    return r
+
+
+async def async_load_module_1(module, async_parse_time=async_parse_time,
+                              compile_time=compile_time, run_time=run_time):
+
+    print(" == async_load_module_1 ==", "await on async_parse_time")
+    source_expr = await async_parse_time(module)
+    print(" == async_load_module_1 ==", source_expr)
+
+    if source_expr is None:
+        raise StopIteration
+
+    else:
+        code_obj = compile_time(module, source_expr)
+        return run_time(module, code_obj)
 
 
 #

--- a/sibilant/parse.py
+++ b/sibilant/parse.py
@@ -573,7 +573,6 @@ class SourceStream(object):
         self.lin = lin
         self.col = col
 
-        print(" == read ==", data)
         return data
 
 
@@ -598,7 +597,6 @@ class SourceStream(object):
             # equivalent
             data = self.read_ahead(count)
 
-        print(" == peeked ==", data)
         return data
 
 

--- a/tests/builtins.py
+++ b/tests/builtins.py
@@ -28,24 +28,11 @@ import sibilant.builtins
 
 from sibilant import car, cdr, cons, nil, symbol
 
-from sibilant.compiler import iter_compile
+from .compiler import compile_expr
 
 
 class Object(object):
     pass
-
-
-def basic_env(**base):
-    env = {"__builtins__": sibilant.builtins}
-    env.update(base)
-    return env
-
-
-def compile_expr(src_str, **base):
-    env = basic_env(**base)
-    icode = iter_compile(src_str, env)
-    code = next(icode)
-    return partial(eval, code, env), env
 
 
 class BuiltinsSetBang(TestCase):

--- a/tests/compiler/specials.py
+++ b/tests/compiler/specials.py
@@ -456,7 +456,7 @@ class CompilerSpecials(TestCase):
 
     def test_define(self):
         src = """
-        (begin
+        (let ()
           (define tacos 100)
           tacos)
         """
@@ -465,7 +465,7 @@ class CompilerSpecials(TestCase):
         self.assertNotIn("tacos", env)
 
         src = """
-        (begin
+        (let ()
           (define tacos 100)
           tacos)
         """

--- a/tests/compiler/tco.py
+++ b/tests/compiler/tco.py
@@ -28,8 +28,9 @@ from unittest import TestCase
 
 import sibilant.builtins
 
-from sibilant.compiler import iter_compile
 from sibilant.compiler.tco import trampoline, tailcall
+
+from . import compile_expr
 
 
 @contextmanager
@@ -38,19 +39,6 @@ def recursionlimit(limit=(getrecursionlimit() // 2)):
     yield setrecursionlimit(limit)
     setrecursionlimit(original)
     assert getrecursionlimit() == original, "could not reset recursion limit"
-
-
-def basic_env(**base):
-    env = {"__builtins__": sibilant.builtins}
-    env.update(base)
-    return env
-
-
-def compile_expr(src_str, **base):
-    env = basic_env(**base)
-    icode = iter_compile(src_str, env)
-    code = next(icode)
-    return partial(eval, code, env), env
 
 
 @trampoline

--- a/tests/module.py
+++ b/tests/module.py
@@ -24,7 +24,8 @@ license: LGPL v.3
 from unittest import TestCase
 
 from sibilant import car, cdr, cons, nil, symbol
-from sibilant.module import load_module
+from sibilant.module import new_module, init_module, load_module
+from sibilant.parse import source_str
 
 
 def getter_setter(value):
@@ -67,8 +68,11 @@ class ModuleTest(TestCase):
         getter, setter = getter_setter(None)
 
         defaults = {"set_result": setter}
-        test_module = load_module("test_module", mod_source_1,
-                                  defaults=defaults)
+
+        test_module = new_module("test_module")
+        init_module(test_module, source_str(mod_source_1), None,
+                    defaults=defaults)
+        load_module(test_module)
 
         # the last action of the module is to call set_result, and
         # getter can show us what was passed there.


### PR DESCRIPTION
* splits up module API based on parse, compile, run times Closes #90
* updates everything that used iter_compile to use the new module API
* updated unittests
* some work on parse to support readahead instead of tell/seek (supporting more stream types, hopefully async pipe in the future) Closes #91