### PR TITLE
Perform more selective bouncing in tailcall positions.

### DIFF
--- a/sibilant/_bootstrap_builtins.py
+++ b/sibilant/_bootstrap_builtins.py
@@ -65,13 +65,8 @@ def setup(glbls):
         __str__ = __repr__
 
 
-    def _op(opf, name=None, rename=False, tco_disable=False):
+    def _op(opf, name=None, rename=False):
         name = name if name else opf.__name__
-
-        if tco_disable:
-            if not isinstance(opf, partial):
-                opf = wraps(opf)(builtin_partial(opf))
-            opf = tco.tco_disable(opf)
 
         if rename:
             opf.__name__ = name
@@ -429,12 +424,12 @@ def setup(glbls):
     _val(object, "object")
 
     _op(__import__, "import")
-    _op(globals, "globals", tco_disable=True)
-    _op(locals, "locals", tco_disable=True)
+    _op(globals, "globals")
+    _op(locals, "locals")
     _op(compile, "py-compile")
     _op(eval, "py-eval")
 
-    _op(sys.exit, "exit", tco_disable=True)
+    _op(sys.exit, "exit")
 
 
     # done with setup

--- a/sibilant/compiler/tco.py
+++ b/sibilant/compiler/tco.py
@@ -66,11 +66,12 @@ def setup():
             return work
 
         tco_trampoline._tco_original = fun
+        tco_trampoline._tco_enable = True
         return tco_trampoline
 
 
     def tailcall(fun):
-        if _ga(fun, "_tco_disable", False):
+        if not _ga(fun, "_tco_enable", False):
             return fun
 
         # if fun is already a wrapped tailcall, or it's a wrapped
@@ -89,10 +90,14 @@ def setup():
         bounce the given function
         """
 
-        fun._tco_disable = True
+        fun._tco_enable = False
 
         return fun
 
+
+    trampoline.__qualname__ = "sibilant.tco.trampoline"
+    tailcall.__qualname__ = "sibilant.tco.tailcall"
+    tco_disable.__qualname__ = "sibilant.tco.tco_disable"
 
     return trampoline, tailcall, tco_disable
 


### PR DESCRIPTION
* only tailcall when _tco_enabled is set to True on the function
* trampolines set _tco_enabled to True
* the tco_disable function now sets _tco_enabled to False
* fix the qualified names of trampoline, tailcall and tco_disable

Closes #103