### PR TITLE
kw-only parameters and metaclass in class definitions

### DIFF
--- a/sibilant/_builtins.lspy
+++ b/sibilant/_builtins.lspy
@@ -382,11 +382,13 @@
 
 
 (defmacro class (name bases . body)
-  `(type
-    ,(str name)
-    (values ,@bases)
-    (let ((fields (lambda (__module__) (begin ,@body) (locals))))
-      (fields __name__))))
+  `(flet ((create-class (name fields *: bases metaclass: type)
+			(metaclass name bases fields))
+	  (create-fields (__module__) (begin ,@body) (locals)))
+
+     (create-class ,(str name)
+		   (create-fields __name__)
+		   ,@bases)))
 
 
 (defmacro compile (source env: '(globals) filename: "<anon>")


### PR DESCRIPTION
* updates the gather_formals function to collect keyword:default
  bindings, and also keyword-only:default bindings for keyword
  parameters specified after a positional variadic

* updates the class macro to allos a metaclass keyword as part of the
  type parents declarations

Closes #106
Closes #107