### PR TITLE
Use built-in buffering for seek

### DIFF
--- a/tests/compiler/__init__.py
+++ b/tests/compiler/__init__.py
@@ -53,7 +53,7 @@ class Object(object):
 
 def compile_expr(src_str, **base):
     mod = fake_module_from_env(base)
-    init_module(mod, source_str(src_str), None)
+    init_module(mod, source_str(src_str, "<unittest>"), None)
 
     partial_run_time = partial(partial, run_time)
 
@@ -67,7 +67,7 @@ def compile_expr_no_tco(src_str, **base):
 
     params = {"tco_enabled": False}
 
-    init_module(mod, source_str(src_str), None,
+    init_module(mod, source_str(src_str, "<unittest>"), None,
                 compiler_factory_params=params)
 
     partial_run_time = partial(partial, run_time)
@@ -79,7 +79,7 @@ def compile_expr_no_tco(src_str, **base):
 
 def compile_dis_expr(src_str, **base):
     mod = fake_module_from_env(base)
-    init_module(mod, source_str(src_str), None)
+    init_module(mod, source_str(src_str, "<unittest>"), None)
 
     code_objs = []
     def partial_run_time(module, code_obj):

--- a/tests/module.py
+++ b/tests/module.py
@@ -69,9 +69,10 @@ class ModuleTest(TestCase):
 
         defaults = {"set_result": setter}
 
+        source = source_str(mod_source_1, "<unittest>")
         test_module = new_module("test_module")
-        init_module(test_module, source_str(mod_source_1), None,
-                    defaults=defaults)
+
+        init_module(test_module, source, None, defaults=defaults)
         load_module(test_module)
 
         # the last action of the module is to call set_result, and

--- a/tests/parse.py
+++ b/tests/parse.py
@@ -30,7 +30,7 @@ from sibilant.parse import default_reader, source_str
 
 def parse_source(src_str):
     reader = default_reader
-    stream = source_str(src_str)
+    stream = source_str(src_str, "<unittest>")
     return reader.read(stream)
 
 
@@ -324,7 +324,7 @@ class TestParse(TestCase):
         src = """
         1.0 "2" (3)
         """
-        strm = source_str(src)
+        strm = source_str(src, "<unittest>")
         read = default_reader.read
 
         a = read(strm)
@@ -343,7 +343,7 @@ class PositionsTest(TestCase):
         src = """
         (hello world)
         """
-        strm = source_str(src)
+        strm = source_str(src, "<unittest>")
         expr = default_reader.read(strm)
 
         self.assertEqual(expr.get_position(), (2, 8))
@@ -356,7 +356,7 @@ class PositionsTest(TestCase):
         (hello (world)
          how are you)
         """
-        strm = source_str(src)
+        strm = source_str(src, "<unittest>")
         expr = default_reader.read(strm)
 
         self.assertEqual(expr.get_position(), (2, 8))


### PR DESCRIPTION
* ditched awful read-ahead impl
* require SourceReader instances to specify filename

Closes #111