### PR TITLE
Use `install_requires` in setup.py instead of `requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(name = "sibilant",
       description = "LISP dialect for Python",
 
       provides = ["sibilant", ],
-      requires = ["appdirs", ],
+      install_requires = ["appdirs", ],
       platforms = ["python3 >= 3.5", ],
 
       zip_safe = True,


### PR DESCRIPTION
Both `setup.py develop` and `pip install -e` won't install dependencies from `requires`, but they will for `install_requires`.