### PR TITLE
build-tuple, build-list, build-set, and build-dict operators

### DIFF
--- a/sibilant/__init__.py
+++ b/sibilant/__init__.py
@@ -28,7 +28,8 @@ import operator
 from .ctypes import symbol, keyword
 from .ctypes import pair, nil, cons, car, cdr, setcar, setcdr
 from .ctypes import merge_pairs, build_unpack_pair
-from .ctypes import reapply, build_tuple
+from .ctypes import reapply
+from .ctypes import build_tuple, build_list, build_set, build_dict
 
 
 __all__ = (
@@ -43,7 +44,9 @@ __all__ = (
     "build_proper", "unpack",
     "copy_pair", "merge_pairs", "build_unpack_pair",
 
-    "reapply", "repeat", "build_tuple",
+    "reapply", "repeat",
+
+    "build_tuple", "build_list", "build_set", "build_dict",
 )
 
 

--- a/sibilant/_bootstrap_builtins.py
+++ b/sibilant/_bootstrap_builtins.py
@@ -229,7 +229,7 @@ def setup(glbls):
     _op(_count, "count", rename=True)
 
 
-    def _apply(fun, arglist=(), kwargs={}):
+    def apply(fun, arglist=(), kwargs={}):
         """
         (apply FUN)
         (apply FUN arglist: POSITIONALS)
@@ -254,29 +254,21 @@ def setup(glbls):
             arglist = arglist.unpack()
         return fun(*arglist, **kwargs)
 
-    _op(_apply, "apply", rename=True)
+    _op(apply, "apply", rename=True)
 
 
-    _op(sibilant.build_tuple, "values")
-    _op(sibilant.build_tuple, "build-tuple")
+    # _op(sibilant.build_tuple, "values")
+    # _op(sibilant.build_tuple, "build-tuple")
     _ty(tuple, "tuple")
 
-
-    _op((lambda *vals: list(vals)), "build-list", rename=True)
+    # _op(sibilant.build_list, "build-list")
     _ty(list, "list")
 
-
-    def _build_dict(*pairs):
-        pairs = ((p.unpack() if is_pair(p) else p) for p in pairs)
-        return dict(pairs)
-
-
+    # _op(sibilant.build_dict, "build-dict")
     _ty(dict, "dict")
-    _op(_build_dict, "build-dict", rename=True)
 
-
+    # _op(sibilant.build_set, "build-set")
     _ty(set, "set")
-    _op((lambda *vals: set(vals)), "build-set", rename=True)
 
     _op(lambda value: hasattr(value, "__iter__"),
         "iterable?", rename=True)

--- a/sibilant/_builtins.lspy
+++ b/sibilant/_builtins.lspy
@@ -313,7 +313,7 @@
   optionally assigns it the value from EXPR
   ")
 
-  (setq variables (to-tuple variables))
+  ;; (setq variables (to-tuple variables))
   `(begin ,@(map (lambda (d)
 		   (if (symbol? d)
 		       then: `(var ,d)

--- a/sibilant/compiler/__init__.py
+++ b/sibilant/compiler/__init__.py
@@ -348,6 +348,8 @@ class Pseudop(Enum):
     BUILD_TUPLE_UNPACK = _auto()
     BUILD_MAP = _auto()
     BUILD_MAP_UNPACK = _auto()
+    BUILD_LIST = _auto()
+    BUILD_SET = _auto()
     SETUP_WITH = _auto()
     WITH_CLEANUP_START = _auto()
     WITH_CLEANUP_FINISH = _auto()
@@ -1292,6 +1294,14 @@ class CodeSpace(metaclass=ABCMeta):
         self.pseudop(Pseudop.BUILD_TUPLE, count)
 
 
+    def pseudop_build_list(self, count):
+        self.pseudop(Pseudop.BUILD_LIST, count)
+
+
+    def pseudop_build_set(self, count):
+        self.pseudop(Pseudop.BUILD_SET, count)
+
+
     def pseudop_build_tuple_unpack(self, count):
         self.pseudop(Pseudop.BUILD_TUPLE_UNPACK, count)
 
@@ -1555,7 +1565,9 @@ class CodeSpace(metaclass=ABCMeta):
             pop()
             push(args[0] + args[1] + 1)
 
-        elif op in (_Pseudop.BUILD_TUPLE,
+        elif op in (_Pseudop.BUILD_LIST,
+                    _Pseudop.BUILD_SET,
+                    _Pseudop.BUILD_TUPLE,
                     _Pseudop.BUILD_TUPLE_UNPACK,
                     _Pseudop.BUILD_MAP_UNPACK):
             pop(args[0])

--- a/sibilant/compiler/cpython35.py
+++ b/sibilant/compiler/cpython35.py
@@ -273,6 +273,12 @@ class CPython35(ExpressionCodeSpace):
             elif op is _Pseudop.BUILD_MAP_UNPACK:
                 yield _Opcode.BUILD_MAP_UNPACK, args[0], 0
 
+            elif op is _Pseudop.BUILD_LIST:
+                yield _Opcode.BUILD_LIST, args[0], 0
+
+            elif op is _Pseudop.BUILD_SET:
+                yield _Opcode.BUILD_SET, args[0], 0
+
             elif op is _Pseudop.SETUP_WITH:
                 yield _Opcode.SETUP_WITH, args[0], 0
 

--- a/sibilant/compiler/cpython36.py
+++ b/sibilant/compiler/cpython36.py
@@ -278,6 +278,12 @@ class CPython36(ExpressionCodeSpace):
             elif op is _Pseudop.BUILD_MAP_UNPACK:
                 yield _Opcode.BUILD_MAP_UNPACK, args[0]
 
+            elif op is _Pseudop.BUILD_LIST:
+                yield _Opcode.BUILD_LIST, args[0]
+
+            elif op is _Pseudop.BUILD_SET:
+                yield _Opcode.BUILD_SET, args[0]
+
             elif op is _Pseudop.SETUP_WITH:
                 yield _Opcode.SETUP_WITH, args[0]
 

--- a/tests/sibilant/builtins.lspy
+++ b/tests/sibilant/builtins.lspy
@@ -139,10 +139,10 @@
 
      (def function test_build_dict (self)
 	  (var data (build-dict
-		     '("foo" 100)
-		     '("bar" 200)
-		     '(tacos "yummy")
-		     (values None 'wut)))
+		     ("foo" 100)
+		     ("bar" 200)
+		     ('tacos "yummy")
+		     (None 'wut)))
 
 	  (self.assertTrue (dict? data))
 	  (self.assertEqual (len data) 4)


### PR DESCRIPTION
* (build-tuple ARG...) evaluates to a tuple of the arguments
* (build-list ARG...) evaluates to a list of the arguments
* (build-set ARG...) evaluates to a set of the arguments
* (build-dict (KEY VAL)...) evaluates to a dictionary

These can be used at compile time to produce the literal pythonic
expressions using the bytecode operations directly. They can also be
used at run-time to similar effect.
  
Closes #139 