### PR TITLE
Some small tweaks to parser utility functions.

### DIFF
--- a/sibilant/__init__.py
+++ b/sibilant/__init__.py
@@ -62,6 +62,21 @@ class NotYetImplemented(SibilantException):
     pass
 
 
+class SibilantSyntaxError(SyntaxError):
+    """
+    An error in sibilant syntax, either during read or compile time.
+    """
+
+    def __init__(self, message, location=None, filename=None, text=None):
+        if filename:
+            if not location:
+                location = (1, 0)
+            super().__init__(message, (filename, *location, text))
+            self.print_file_and_line = True
+        else:
+            super().__init__(message)
+
+
 class TypePredicate(partial):
     def __new__(cls, name, typeobj):
         obj = partial.__new__(cls, typeobj.__instancecheck__)

--- a/sibilant/compiler/__init__.py
+++ b/sibilant/compiler/__init__.py
@@ -26,17 +26,16 @@ from sys import version_info
 from types import CodeType
 
 from .. import (
-    SibilantException,
+    SibilantException, SibilantSyntaxError,
     symbol, is_symbol, keyword, is_keyword,
     cons, nil, is_pair, is_proper,
     get_position, fill_position,
 )
 
-from ..parse import SibilantSyntaxError
-
 
 __all__ = (
-    "SpecialSyntaxError", "UnsupportedVersion",
+    "UnsupportedVersion",
+    "CompilerSyntaxError",
     "Opcode", "Pseudop", "Block",
     "CodeSpace", "ExpressionCodeSpace",
     "code_space_for_version",
@@ -1955,7 +1954,7 @@ def compile_expression(source_obj, env, filename="<anon>",
     return code
 
 
-def gather_formals(args, declared_at=None):
+def gather_formals(args, declared_at=None, filename=None):
     """
     parses formals pair args into five values:
     (positional, keywords, defaults, stararg, starstararg)
@@ -1976,7 +1975,8 @@ def gather_formals(args, declared_at=None):
     undefined = object()
 
     def err(msg):
-        return SibilantSyntaxError(msg, declared_at)
+        return SibilantSyntaxError(msg, location=declared_at,
+                                   filename=filename)
 
     if is_symbol(args):
         return ((), (), (), args, None)
@@ -2110,7 +2110,7 @@ def simple_parameters(source_args, declared_at=None):
     return args, kwargs
 
 
-def gather_parameters(args, declared_at=None):
+def gather_parameters(args, declared_at=None, filename=None):
     """
     parses parameter args into five values:
     (positional, keywords, values, stararg, starstararg)
@@ -2125,7 +2125,8 @@ def gather_parameters(args, declared_at=None):
     undefined = object()
 
     def err(msg):
-        return SibilantSyntaxError(msg, declared_at)
+        return SibilantSyntaxError(msg, location=declared_at,
+                                   filename=filename)
 
     if is_symbol(args):
         return ((), (), (), args, None)

--- a/sibilant/parse.py
+++ b/sibilant/parse.py
@@ -45,26 +45,26 @@ _splice_sym = symbol("splice")
 _fraction_sym = symbol("fraction")
 
 
-_integer_like = partial(regex(r"-?\d+").match)
+_integer_like = regex(r"-?\d+").match
 
-_hex_like = partial(regex(r"0x[\da-f]+").match)
+_hex_like = regex(r"0x[\da-f]+").match
 
-_oct_like = partial(regex(r"0o[0-7]+").match)
+_oct_like = regex(r"0o[0-7]+").match
 
-_bin_like = partial(regex(r"0b[01]+").match)
+_bin_like = regex(r"0b[01]+").match
 
-_float_like = partial(regex(r"-?((\d*\.\d+|\d+\.\d*)(e-?\d+)?|"
-                            "(\d+e-?\d+))").match)
+_float_like = regex(r"-?((\d*\.\d+|\d+\.\d*)(e-?\d+)?|"
+                    "(\d+e-?\d+))").match
 
-_fraction_like = partial(regex(r"-?\d+/\d+").match)
+_fraction_like = regex(r"-?\d+/\d+").match
 
-_complex_like = partial(regex(r"-?\d*\.?\d+\+\d*\.?\d*[ij]").match)
+_complex_like = regex(r"-?\d*\.?\d+\+\d*\.?\d*[ij]").match
 
-_keyword_like = partial(regex(r"^(:.+|.+:)$").match)
+_keyword_like = regex(r"^(:.+|.+:)$").match
 
-_as_float = partial(float)
+_as_float = float
 
-_as_integer = partial(int)
+_as_integer = int
 
 _as_hex = partial(int, base=16)
 
@@ -97,6 +97,7 @@ def _as_complex(s):
         return complex(s)
 
 
+IN_PROGRESS = keyword("work-in-progress")
 VALUE = keyword("value")
 DOT = keyword("dot")
 SKIP = keyword("skip")
@@ -146,6 +147,24 @@ class Reader(object):
         elif event is EOF:
             # TODO: could probably raise error?
             return None
+        else:
+            raise reader_stream.error("invalid syntax", pos)
+
+
+    def read_and_position(self, reader_stream):
+        """
+        Returns a cons cell, symbol, or numeric value. Returns None if no
+        data left in stream. Raises ReaderSyntaxError to complain
+        about syntactic difficulties in the stream.
+        """
+
+        event, pos, value = self._read(reader_stream)
+
+        if event is VALUE:
+            return value, pos
+        elif event is EOF:
+            # TODO: could probably raise error?
+            return None, pos
         else:
             raise reader_stream.error("invalid syntax", pos)
 


### PR DESCRIPTION
* Re-homed SibilantSyntaxException from sibilant.compiler to sibilant
* add a flag to skip the exec header for parser wrapper functions
* remove useless partial wrappers around atom matchers