### PR TITLE
build-string operator

### DIFF
--- a/examples/flasky.lspy
+++ b/examples/flasky.lspy
@@ -5,7 +5,7 @@
 (def import-from werkzeug.routing parse_rule)
 
 
-(defmacro url-rule (app name rule . body)
+(defmacro url-rule (name rule . body)
   (define formals
     (iter-each ((converter wut name) (parse_rule (str rule)))
 	       (symbol name) unless: (None? converter)))
@@ -15,18 +15,22 @@
 		     view_func: (function ,name (,@formals) ,@body)))
 
 
-
 (defmacro template strings
   `(str.format (str.join " " (map str (#tuple ,@strings))) **: (locals)))
+
+
+(defmacro declare-app (name)
+  `(define app (Flask ,(str name))))
+
 
 ;;;
 
 
-(define app (Flask "flasky"))
+(declare-app flasky)
 
 
 (url-rule
- app index /
+ index /
 
  (define lcls (escape (locals)))
  (template
@@ -35,14 +39,17 @@
 
 
 (url-rule
- app reverse-words /reverse/<words>
+ reverse-words /reverse/<words>
 
- (define rwords (str.join "" (reversed words)))
+ (define rwords (escape (item-slice words step: -1)))
+ (define words (escape words))
  (define lcls (escape (locals)))
- (template
-  "<p>\U0001f615 Reversed this: {words}</p>"
-  "<p>\U0001f60e Into this: {rwords}</p>"
-  "<code>{lcls}</code>"))
+
+ (#str
+  "<code>\n"
+  "<p>\U0001f615 Original: " words "</p>\n"
+  "<p>\U0001f60e Reversed: " rwords "</p>\n"
+  "<p>Locals: " lcls "</p></code>\n"))
 
 
 ;; you can either run this directly, or you can compile it to a .pyc

--- a/sibilant/compiler/__init__.py
+++ b/sibilant/compiler/__init__.py
@@ -320,6 +320,7 @@ class Pseudop(Enum):
     BUILD_MAP = _auto()
     BUILD_MAP_UNPACK = _auto()
     BUILD_SET = _auto()
+    BUILD_STR = _auto()
     BUILD_TUPLE = _auto()
     BUILD_TUPLE_UNPACK = _auto()
     CALL = _auto()
@@ -1310,6 +1311,10 @@ class CodeSpace(metaclass=ABCMeta):
         self.pseudop(Pseudop.RAISE, count)
 
 
+    def pseudop_build_str(self, count):
+        self.pseudop(Pseudop.BUILD_STR, count)
+
+
     def pseudop_build_tuple(self, count):
         self.pseudop(Pseudop.BUILD_TUPLE, count)
 
@@ -1470,6 +1475,7 @@ class CodeSpace(metaclass=ABCMeta):
 
         elif op in (_Pseudop.BUILD_LIST,
                     _Pseudop.BUILD_SET,
+                    _Pseudop.BUILD_STR,
                     _Pseudop.BUILD_TUPLE,
                     _Pseudop.BUILD_TUPLE_UNPACK,
                     _Pseudop.BUILD_MAP_UNPACK):

--- a/sibilant/compiler/cpython35.py
+++ b/sibilant/compiler/cpython35.py
@@ -417,6 +417,17 @@ class CPython35(ExpressionCodeSpace):
                 assert False, "Unknown Pseudop %r" % op
 
 
+    def pseudop_build_str(self, count):
+        # emulate the BUILD_STRING opcode using string joining
+
+        self.pseudop_build_tuple(count)
+
+        self.pseudop_const("")
+        self.pseudop_get_attr("join")
+        self.pseudop_rot_two()
+        self.pseudop_call(1)
+
+
     def pseudop_lambda(self, code, defaults=(), kwonly=()):
         for arg, expr in defaults:
             self.add_expression(expr)

--- a/sibilant/compiler/cpython36.py
+++ b/sibilant/compiler/cpython36.py
@@ -304,6 +304,9 @@ class CPython36(ExpressionCodeSpace):
             elif op is _Pseudop.BUILD_SET:
                 yield _Opcode.BUILD_SET, args[0]
 
+            elif op is _Pseudop.BUILD_STR:
+                yield _Opcode.BUILD_STRING, args[0]
+
             elif op is _Pseudop.SETUP_WITH:
                 yield _Opcode.SETUP_WITH, args[0]
 

--- a/tests/operators.py
+++ b/tests/operators.py
@@ -1909,6 +1909,112 @@ class Comparators(TestCase):
         """
         stmt, env = compile_expr(src)
         res = stmt()
+        self.assertEqual(res, True)
+
+
+class TypeBuilders(TestCase):
+
+    def test_build_dict(self):
+        src = """
+        (#dict)
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertIs(type(res), dict)
+        self.assertEqual(res, dict())
+
+        src = """
+        (#dict ("foo" 1)
+               ("bar" 2))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertIs(type(res), dict)
+        self.assertEqual(res, dict(foo=1, bar=2))
+
+
+    def test_build_list(self):
+        src = """
+        (#list)
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertIs(type(res), list)
+        self.assertEqual(res, list())
+
+        src = """
+        (#list 1 2 3)
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertIs(type(res), list)
+        self.assertEqual(res, [1, 2, 3])
+
+
+    def test_build_set(self):
+        src = """
+        (#set)
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertIs(type(res), set)
+        self.assertEqual(res, set())
+
+        src = """
+        (#set 1 2 3)
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertIs(type(res), set)
+        self.assertEqual(res, {1, 2, 3})
+
+
+    def test_build_tuple(self):
+        src = """
+        (#tuple)
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertIs(type(res), tuple)
+        self.assertEqual(res, tuple())
+
+        src = """
+        (#tuple 1 2 3)
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertIs(type(res), tuple)
+        self.assertEqual(res, (1, 2, 3))
+
+
+    def test_build_str(self):
+        src = """
+        (#str)
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertIs(type(res), str)
+        self.assertEqual(res, "")
+
+        src = """
+        (#str "a" "b" "c")
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertIs(type(res), str)
+        self.assertEqual(res, "abc")
+
+        src = """
+        (lambda (X) (#str "a" "b" X "c"))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        code = res.__code__
+        self.assertEqual(code.co_consts[0], None)
+        self.assertEqual(code.co_consts[1], "ab")
+        self.assertEqual(code.co_consts[2], "c")
+        self.assertEqual(res(""), "abc")
+        self.assertEqual(res(" "), "ab c")
 
 
 #


### PR DESCRIPTION
* build-str uses the BUILD_STRING opcode when available to compose a
  string from sub-strings
* unit tests for same