### PR TITLE
Support for reading raw atoms in reader macros

### DIFF
--- a/examples/reader-macro.lspy
+++ b/examples/reader-macro.lspy
@@ -22,15 +22,24 @@
 
 
 ;; a contrived dollars class, based on the float type.
-(defclass dollars [float]
+(defclass dollars [decimal]
   " Simple wrapper for float which formats the value as a dollars.
     Please don't ever actually represent currency using a float, this
     is just because I am being very lazy for this example. "
 
   (def function __str__ [self]
-	  (% "$%0.02f" self))
+       (% "$%0.02f" self))
   (def function __repr__ [self]
-	  (% "(dollars %0.02f)" self)))
+       (% "(dollars %0.02f)" self))
+
+  (def function __add__ [self other]
+       (dollars (+ (decimal self) (decimal other))))
+
+  (def function __sub__ [self other]
+       (dollars (- (decimal self) (decimal other)))))
+
+
+(def import-from sibilant.parse [_float_re as: float-like])
 
 
 ;; here's a very simple reader macro based on the dollarsign
@@ -39,7 +48,23 @@
 ;; that value. In this case, simply wrapping whatever is read in a
 ;; call to dollars
 (defun read-dollars [stream c]
-  `(dollars ,(read stream)))
+  (var [found (read-atom stream)])
+
+  ;; here's some magic. If the dollars argument appears to be a float
+  ;; literal, which is the default for decimal-like values, munge it
+  ;; to be a decimal literal instead.
+  ;; eg:  1.00 becomes 1.00d
+  ;;      1.5f becomes 1.fd
+  (when (atom? found)
+    (when (float-like found)
+      (setq found
+	    (if (found.endswith "f")
+		then: (#str (item-slice found stop: -1) "d")
+		else: (#str found "d"))))
+    (setq found (process-atom found)))
+
+  ;; process the munged atom, turning it into the parser's default form
+  `(dollars ,found))
 
 (set-macro-character "$" read-dollars terminating: False)
 

--- a/sibilant/basics.lspy
+++ b/sibilant/basics.lspy
@@ -81,6 +81,8 @@
        ([NameError as: ne] None))))
 
 (_reader_macro read read)
+(_reader_macro read-atom read_atom)
+(_reader_macro process-atom process_atom)
 (_reader_macro set-event-macro set_event_macro)
 (_reader_macro get-event-macro get_event_macro)
 (_reader_macro clear-event-macro clear_event_macro)

--- a/sibilant/bootstrap.py
+++ b/sibilant/bootstrap.py
@@ -56,6 +56,8 @@ def __setup__(glbls):
     import sibilant.specials as specials
     import sibilant.operators as operators
 
+    from sibilant.parse import Atom as atom
+
 
     _all_ = []
 
@@ -154,6 +156,8 @@ def __setup__(glbls):
     _op(tco.tailcall_enable, "tailcall-enable")
 
     _op(compiler.current, "active-compiler")
+
+    _ty(atom, "atom")
 
 
     # === some python builtin types ===


### PR DESCRIPTION
* read-raw receives an atom instead of a processed atomic type
* see examples/reader-macro.lspy for usage

Closes #173