### PR TITLE
Reverse ordering on operators `in`, `not-in`

### DIFF
--- a/examples/sibilant-life/siblife/curse.lspy
+++ b/examples/sibilant-life/siblife/curse.lspy
@@ -216,28 +216,28 @@
 	      (setq event (chr event))
 
 	      (cond
-	       [(in " \n" event)
+	       [(contains " \n" event)
 		(board.toggle x-pos y-pos)
 		(board.display)]
 
-	       [(in "Cc" event)
+	       [(contains "Cc" event)
 		(continuous-mode stdscr board menu-y)]
 
-	       [(in "Ee" event)
+	       [(contains "Ee" event)
 		(board.clear)
 		(board.display)]
 
-	       [(in "Qq" event)
+	       [(contains "Qq" event)
 		(break)]
 
-	       [(in "Rr" event)
+	       [(contains "Rr" event)
 		(board.randomize)
 		(board.display)]
 
-	       [(in "Ss" event)
+	       [(contains "Ss" event)
 		(step stdscr board)]
 
-	       [(in "1234567890" event)
+	       [(contains "1234567890" event)
 		(multi-step stdscr board menu-y
 			    (** 10 (str.index "1234567890" event)))]
 

--- a/sibilant/basics.lspy
+++ b/sibilant/basics.lspy
@@ -177,6 +177,17 @@
 ;; === optimized assert
 
 (defmacro assert [expr message: None]
+  """
+  (assert EXPR)
+  (assert EXPR message: VALUE)
+
+  Raises an AssertionError if EXPR is not True. Optionally provides a
+  VALUE expression which will be evaluated only if the assertion EXPR is
+  not True.
+
+  This macro honors the Python optimization flags, and will have no
+  effect if sys.flags.optimize is non-zero
+  """
   (unless sys.flags.optimize
 	  (if (None? message)
 	      then: `(unless ,expr (raise! AssertionError))
@@ -209,12 +220,12 @@
 
     (cond
      [(symbol? target)
-      (if (in (str target) ".")
+      (if (contains (str target) ".")
 	  then: { (define spltrgt (target.rsplit "." 1))
 		  `(set-attr ,(item spltrgt 0) ,(item spltrgt 1) ,value) }
 	  else:	`(setq ,target ,value))]
 
-     [(and (proper? target) (in *gv-forms* (car target)))
+     [(and (proper? target) (contains *gv-forms* (car target)))
       ((item *gv-forms* (car target)) (cdr target) value)]
 
      [else:
@@ -336,7 +347,7 @@
 
        (else:
 	(define ats `(import ,module))
-	(when (in (str module) ".")
+	(when (contains (str module) ".")
 	  (setq ats (reduce (lambda [t h] `(attr ,t ,h))
 			    (item-slice (module.split ".") start: 1)
 			    ats)))

--- a/sibilant/operators.py
+++ b/sibilant/operators.py
@@ -56,6 +56,7 @@ _symbol_build_list = symbol("build-list")
 _symbol_build_set = symbol("build-set")
 _symbol_build_str = symbol("build-str")
 _symbol_build_tuple = symbol("build-tuple")
+_symbol_contains = symbol("contains")
 _symbol_del_item = symbol("del-item")
 _symbol_div = symbol("divide")
 _symbol_div_ = symbol("/")
@@ -92,6 +93,7 @@ _symbol_mult = symbol("multiply")
 _symbol_mult_ = symbol("*")
 _symbol_nil = symbol("nil")
 _symbol_not = symbol("not")
+_symbol_not_contains = symbol("not-contains")
 _symbol_not_eq = symbol("not-eq")
 _symbol_not_eq_ = symbol("!=")
 _symbol_not_in = symbol("not-in")
@@ -594,24 +596,52 @@ def operator_ge(code, source, tc=False):
     _helper_binary(code, source, code.pseudop_compare_gte)
 
 
-@operator(_symbol_in, pyop.contains)
-def operator_in(code, source, tc=False):
+@operator(_symbol_contains, pyop.contains)
+def operator_contains(code, source, tc=False):
     """
-    (in SEQ VALUE)
-    True if SEQ contains VALUE
+    (contains SEQUENCE VALUE)
+    True if SEQUENCE contains VALUE
+
+    Identical to (in VALUE SEQUENCE)
     """
 
     _helper_binary(code, source, code.pseudop_compare_in, True)
 
 
-@operator(_symbol_not_in, (lambda seq, value: value not in seq))
-def operator_not_in(code, source, tc=False):
+@operator(_symbol_in, (lambda value, seq: value in seq))
+def operator_in(code, source, tc=False):
     """
-    (not-in SEQ VALUE)
-    False if SEQ contains VALUE
+    (in VALUE SEQUENCE)
+    True if SEQUENCE contains VALUE
+
+    Identical to (contains SEQUENCE VALUE)
+    """
+
+    _helper_binary(code, source, code.pseudop_compare_in)
+
+
+@operator(_symbol_not_contains, (lambda seq, value: value not in seq))
+def operator_not_contains(code, source, tc=False):
+    """
+    (not-contains SEQUENCE VALUE)
+    False if SEQUENCE contains VALUE
+
+    Identical to (not-in VALUE SEQUENCE)
     """
 
     _helper_binary(code, source, code.pseudop_compare_not_in, True)
+
+
+@operator(_symbol_not_in, (lambda value, seq: value not in seq))
+def operator_not_in(code, source, tc=False):
+    """
+    (not-in VALUE SEQUENCE)
+    False if SEQUENCE contains VALUE
+
+    Identical to (not-contains SEQUENCE VALUE)
+    """
+
+    _helper_binary(code, source, code.pseudop_compare_not_in)
 
 
 @operator(_symbol_is, pyop.is_)

--- a/tests/operators.py
+++ b/tests/operators.py
@@ -1429,14 +1429,14 @@ class Comparators(TestCase):
 
     def test_in(self):
         src = """
-        (in X 1)
+        (in 1 X)
         """
         stmt, env = compile_expr(src, X=[0, 1, 2])
         res = stmt()
         self.assertEqual(res, True)
 
         src = """
-        (in X 9)
+        (in 9 X)
         """
         stmt, env = compile_expr(src, X=[0, 1, 2])
         res = stmt()
@@ -1445,14 +1445,46 @@ class Comparators(TestCase):
 
     def test_apply_in(self):
         src = """
-        (apply in `(,X 1))
+        (apply in `(1 ,X))
         """
         stmt, env = compile_expr(src, X=[0, 1, 2])
         res = stmt()
         self.assertEqual(res, True)
 
         src = """
-        (apply in `(,X 9))
+        (apply in `(9 ,X))
+        """
+        stmt, env = compile_expr(src, X=[0, 1, 2])
+        res = stmt()
+        self.assertEqual(res, False)
+
+
+    def test_contains(self):
+        src = """
+        (contains X 1)
+        """
+        stmt, env = compile_expr(src, X=[0, 1, 2])
+        res = stmt()
+        self.assertEqual(res, True)
+
+        src = """
+        (contains X 9)
+        """
+        stmt, env = compile_expr(src, X=[0, 1, 2])
+        res = stmt()
+        self.assertEqual(res, False)
+
+
+    def test_apply_contains(self):
+        src = """
+        (apply contains `(,X 1))
+        """
+        stmt, env = compile_expr(src, X=[0, 1, 2])
+        res = stmt()
+        self.assertEqual(res, True)
+
+        src = """
+        (apply contains `(,X 9))
         """
         stmt, env = compile_expr(src, X=[0, 1, 2])
         res = stmt()
@@ -1461,14 +1493,14 @@ class Comparators(TestCase):
 
     def test_not_in(self):
         src = """
-        (not-in X 1)
+        (not-in 1 X)
         """
         stmt, env = compile_expr(src, X=[0, 1, 2])
         res = stmt()
         self.assertEqual(res, False)
 
         src = """
-        (not-in X 9)
+        (not-in 9 X)
         """
         stmt, env = compile_expr(src, X=[0, 1, 2])
         res = stmt()
@@ -1477,14 +1509,46 @@ class Comparators(TestCase):
 
     def test_apply_not_in(self):
         src = """
-        (apply not-in `(,X 1))
+        (apply not-in `(1 ,X))
         """
         stmt, env = compile_expr(src, X=[0, 1, 2])
         res = stmt()
         self.assertEqual(res, False)
 
         src = """
-        (apply not-in `(,X 9))
+        (apply not-in `(9 ,X))
+        """
+        stmt, env = compile_expr(src, X=[0, 1, 2])
+        res = stmt()
+        self.assertEqual(res, True)
+
+
+    def test_not_contains(self):
+        src = """
+        (not-contains X 1)
+        """
+        stmt, env = compile_expr(src, X=[0, 1, 2])
+        res = stmt()
+        self.assertEqual(res, False)
+
+        src = """
+        (not-contains X 9)
+        """
+        stmt, env = compile_expr(src, X=[0, 1, 2])
+        res = stmt()
+        self.assertEqual(res, True)
+
+
+    def test_apply_not_contains(self):
+        src = """
+        (apply not-contains `(,X 1))
+        """
+        stmt, env = compile_expr(src, X=[0, 1, 2])
+        res = stmt()
+        self.assertEqual(res, False)
+
+        src = """
+        (apply not-contains `(,X 9))
         """
         stmt, env = compile_expr(src, X=[0, 1, 2])
         res = stmt()

--- a/tests/sibilant/basics.lspy
+++ b/tests/sibilant/basics.lspy
@@ -163,11 +163,11 @@
 
 	  (self.assertTrue (set? data))
 	  (self.assertEqual (len data) 5)
-	  (self.assertTrue (in data 1))
-	  (self.assertTrue (in data 2))
-	  (self.assertTrue (in data 3))
-	  (self.assertTrue (in data 4))
-	  (self.assertTrue (in data 5))
+	  (self.assertTrue (contains data 1))
+	  (self.assertTrue (contains data 2))
+	  (self.assertTrue (contains data 3))
+	  (self.assertTrue (contains data 4))
+	  (self.assertTrue (contains data 5))
 
 	  None)
 


### PR DESCRIPTION
* reverse operator arguments for `in` and `not-in`
* new `contains` and `not-contains` operators
* (contains sequence value)  ::=  (in value sequence) ::=  value in sequence
* (not-contains sequence value) ::= (not-in value sequence) ::= value not in sequence

Closes #179