### PR TITLE
delf, delq-global, del-attr, del-item, delq

### DIFF
--- a/sibilant/basics.lspy
+++ b/sibilant/basics.lspy
@@ -203,10 +203,11 @@
 
 ;; === setf and general variables ===
 
-(let [[*gv-forms* (#dict)]]
+(let [[*gv-set-forms* (#dict)]
+      [*gv-del-forms* (#dict)]]
 
   (defun gv-define-setter-fn [name fn]
-    (set-item *gv-forms* name fn)
+    (set-item *gv-set-forms* name fn)
     None)
 
   (defmacro gv-define-setter [name formals . body]
@@ -223,7 +224,7 @@
     ;; since sibilant is designed to expand macros lazily, we need to
     ;; jump ahead a bit and make sure that our target gets expanded
     ;; right now so that we can find the right dispatch method.
-    (setq target (macroexpandq None target))
+    (setq target (macroexpandq (globals) target))
 
     (cond
      [(symbol? target)
@@ -232,11 +233,45 @@
 		  `(set-attr ,(item spltrgt 0) ,(item spltrgt 1) ,value) }
 	  else:	`(setq ,target ,value))]
 
-     [(and (proper? target) (contains *gv-forms* (car target)))
-      ((item *gv-forms* (car target)) (cdr target) value)]
+     [(and (proper? target) (contains *gv-set-forms* (car target)))
+      ((item *gv-set-forms* (car target)) (cdr target) value)]
 
      [else:
       (raise! Exception (% "invalid setf target %s" target))]))
+
+
+  (defun gv-define-del-fn [name fn]
+    (set-item *gv-del-forms* name fn)
+    None)
+
+  (defmacro gv-define-del [name formals . body]
+    `(gv-define-del-fn
+      ',name
+      (lambda ,formals ,@body)))
+
+  (defmacro gv-define-simple-del [name del]
+    `(gv-define-del
+      ,name (dest) `(,',del ,@dest)))
+
+  (defmacro delf [target]
+
+    ;; since sibilant is designed to expand macros lazily, we need to
+    ;; jump ahead a bit and make sure that our target gets expanded
+    ;; right now so that we can find the right dispatch method.
+    (setq target (macroexpandq (globals) target))
+
+    (cond
+     [(symbol? target)
+      (if (contains (str target) ".")
+	  then: { (define spltrgt (target.rsplit "." 1))
+		  `(del-attr ,(item spltrgt 0) ,(item spltrgt 1)) }
+	  else:	`(delq ,target))]
+
+     [(and (proper? target) (contains *gv-del-forms* (car target)))
+      ((item *gv-del-forms* (car target)) (cdr target))]
+
+     [else:
+      (raise! Exception (% "invalid delf target %s" target))]))
 
   None)
 
@@ -245,8 +280,12 @@
 (gv-define-simple-setter car set-car)
 (gv-define-simple-setter cdr set-cdr)
 (gv-define-simple-setter item set-item)
-(gv-define-simple-setter global define-global)
+(gv-define-simple-setter global setq-global)
 (gv-define-setter caar [val x] `(set-car (car ,x) ,val))
+
+(gv-define-simple-del attr del-attr)
+(gv-define-simple-del item del-item)
+(gv-define-simple-del global delq-global)
 
 
 ;; === def general targets ===

--- a/sibilant/operators.py
+++ b/sibilant/operators.py
@@ -481,6 +481,7 @@ def operator_del_item(code, source, tc=False):
     """
 
     _helper_binary(code, source, code.pseudop_del_item)
+    code.pseudop_const(None)
 
 
 @operator(_symbol_pow, pyop.pow, _symbol_pow_)

--- a/sibilant/specials.py
+++ b/sibilant/specials.py
@@ -245,7 +245,7 @@ def special_set_attr(code, source, tc=False):
     code.pseudop_rot_two()
     code.pseudop_set_attr(member)
 
-    # make setf calls evaluate to None
+    # make set-attr calls evaluate to None
     code.pseudop_const(None)
 
     # no further transformations
@@ -274,6 +274,9 @@ def special_del_attr(code, source, tc=False):
     code.pseudop_position_of(source)
     code.add_expression(obj)
     code.pseudop_del_attr(member)
+
+    # make del-attr calls evaluate to None
+    code.pseudop_const(None)
 
     # no further transformations
     return None

--- a/tests/specials.py
+++ b/tests/specials.py
@@ -366,50 +366,6 @@ class CompilerSpecials(TestCase):
         self.assertEqual(env["tacos"], 100)
 
 
-    def test_define_global(self):
-        src = """
-        (define-global tacos 100)
-        """
-        stmt, env = compile_expr(src)
-        self.assertEqual(stmt(), None)
-        self.assertEqual(env["tacos"], 100)
-
-        src = """
-        (let ((beer 999))
-          (define-global tacos beer)
-          (define-global beer 777)
-          beer)
-        """
-        stmt, env = compile_expr(src, tacos=5)
-        self.assertEqual(stmt(), 999)
-        self.assertEqual(env["tacos"], 999)
-        self.assertEqual(env["beer"], 777)
-
-
-    def test_get_global(self):
-        src = """
-        (let ((tacos 100))
-          (global tacos))
-        """
-        stmt, env = compile_expr(src, tacos=5)
-        self.assertEqual(stmt(), 5)
-
-        src = """
-        (let ((tacos 100))
-          (+ (global tacos) tacos))
-        """
-        stmt, env = compile_expr(src, tacos=5)
-        self.assertEqual(stmt(), 105)
-
-        src = """
-        (let ((tacos 100))
-          (define-global tacos 90)
-          (+ (global tacos) tacos))
-        """
-        stmt, env = compile_expr(src, tacos=5)
-        self.assertEqual(stmt(), 190)
-
-
     def test_define(self):
         src = """
         (let ()
@@ -1393,6 +1349,82 @@ class Attr(TestCase):
         self.assertEqual(deldata(), None)
         self.assertFalse(hasattr(data, "sample"))
         self.assertRaises(AttributeError, getdata)
+
+
+class GlobalAccessors(TestCase):
+
+
+    def test_setq_global(self):
+        src = """
+        (define-global tacos 100)
+        """
+        stmt, env = compile_expr(src)
+        self.assertEqual(stmt(), None)
+        self.assertEqual(env["tacos"], 100)
+
+        src = """
+        (let ((beer 999))
+          (define-global tacos beer)
+          (define-global beer 777)
+          beer)
+        """
+        stmt, env = compile_expr(src, tacos=5)
+        self.assertEqual(stmt(), 999)
+        self.assertEqual(env["tacos"], 999)
+        self.assertEqual(env["beer"], 777)
+
+        src = """
+        (setq-global tacos 100)
+        """
+        stmt, env = compile_expr(src)
+        self.assertEqual(stmt(), None)
+        self.assertEqual(env["tacos"], 100)
+
+        src = """
+        (let ((beer 999))
+          (setq-global tacos beer)
+          (setq-global beer 777)
+          beer)
+        """
+        stmt, env = compile_expr(src, tacos=5)
+        self.assertEqual(stmt(), 999)
+        self.assertEqual(env["tacos"], 999)
+        self.assertEqual(env["beer"], 777)
+
+
+    def test_global(self):
+        src = """
+        (let ((tacos 100))
+          (global tacos))
+        """
+        stmt, env = compile_expr(src, tacos=5)
+        self.assertEqual(stmt(), 5)
+
+        src = """
+        (let ((tacos 100))
+          (+ (global tacos) tacos))
+        """
+        stmt, env = compile_expr(src, tacos=5)
+        self.assertEqual(stmt(), 105)
+
+        src = """
+        (let ((tacos 100))
+          (define-global tacos 90)
+          (+ (global tacos) tacos))
+        """
+        stmt, env = compile_expr(src, tacos=5)
+        self.assertEqual(stmt(), 190)
+
+
+    def test_delq_global(self):
+        src = """
+        (let ((tacos 100))
+          (delq-global tacos)
+          tacos)
+        """
+        stmt, env = compile_expr(src, tacos=5)
+        self.assertEqual(stmt(), 100)
+        self.assertTrue("tacos" not in env)
 
 
 #

--- a/tests/specials.py
+++ b/tests/specials.py
@@ -1286,9 +1286,9 @@ class SpecielYieldFrom(TestCase):
                                      (2, 3), (1, 4), (0, 5)])
 
 
-class Delq(TestCase):
+class SetqDelq(TestCase):
 
-    def test_delq_closure(self):
+    def test_setq_delq_closure(self):
         src = """
         (let [[data 123]]
           (define-global set-data (function set-data [value]
@@ -1322,7 +1322,7 @@ class Delq(TestCase):
         self.assertRaises(NameError, getdata)
 
 
-    def test_delq_global(self):
+    def test_setq_delq_global(self):
         src = """
         (let []
           (define-global set-data (function set-data [value]
@@ -1358,6 +1358,41 @@ class Delq(TestCase):
         self.assertEqual(deldata(), None)
         self.assertRaises(NameError, getdata)
         self.assertEqual(env.get("data", None), None)
+
+
+class Attr(TestCase):
+
+
+    def test_attr(self):
+
+        src = """
+        (let [[data (Object)]]
+          (define-global set-data (function set-data [value]
+             (set-attr data sample value)))
+          (define-global del-data (function del-data []
+             (del-attr data sample)))
+          (define-global get-data (function get-data []
+             (attr data sample)))
+          data)
+        """
+        stmt, env = compile_expr(src, Object=Object)
+        data = stmt()
+
+        setdata = env["set-data"]
+        getdata = env["get-data"]
+        deldata = env["del-data"]
+
+        self.assertFalse(hasattr(data, "sample"))
+        self.assertRaises(AttributeError, getdata)
+
+        self.assertEqual(setdata(123), None)
+        self.assertTrue(hasattr(data, "sample"))
+        self.assertEqual(getdata(), 123)
+        self.assertEqual(data.sample, 123)
+
+        self.assertEqual(deldata(), None)
+        self.assertFalse(hasattr(data, "sample"))
+        self.assertRaises(AttributeError, getdata)
 
 
 #


### PR DESCRIPTION
* delq will delete a name, searching from closest namespace outwards
* delq-global will delete a name in the global namespace only
* del-attr will delete an attribute from an instance
* del-item will delete an index or slice from sequence
* delf will dispatch to the appropriate operator

Closes #186