### PR TITLE
Add let* and letrec macros

### DIFF
--- a/sibilant/basics.lspy
+++ b/sibilant/basics.lspy
@@ -478,6 +478,21 @@
      ,@body))
 
 
+(defmacro let* [bindings . body]
+  `(let []
+     ,@(map (lambda [b] `(define ,@b))
+            (bindings.unpack))
+     ,@body))
+
+
+(defmacro letrec [bindings . body]
+  `(let [,@(map (lambda [b] `(,(car b) None))
+                (bindings.unpack))]
+     ,@(map (lambda [b] `(define ,@b))
+            (bindings.unpack))
+     ,@body))
+
+
 ;; === c_r magic ===
 
 ;; (defmacro c__r (atom)

--- a/tests/basics.py
+++ b/tests/basics.py
@@ -619,6 +619,40 @@ class IterEach(TestCase):
         self.assertEqual(type(res), set)
         self.assertEqual(res, set())
 
+class Lets(TestCase):
+
+
+    def test_let_star(self):
+        src = """
+        (let* [[pre "te"][post (+ pre "st")]] post)
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+
+        self.assertEqual(res, "test")
+
+        src = """
+        (let* [[post (+ pre "st")][pre "te"]] post)
+        """
+        stmt, env = compile_expr(src)
+
+        self.assertRaises(UnboundLocalError, stmt)
+
+
+    def test_letrec(self):
+        src = """
+        (letrec [[is-even? (lambda (n) (or (== n 0)
+                                       (is-odd? (- n 1))))]
+                 [is-odd? (lambda (n) (and (not (== n 0))
+                                           (is-even? (- n 1))))]]
+                (is-odd? 11))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+
+        self.assertEqual(res, True)
+
+
 
 class Attrs(TestCase):
 


### PR DESCRIPTION
let* is like let except each binding is defined in order, so later
values can refer to earlier ones.

letrec is like let* except the bindings are all created first, then the
values are applied in order, so earlier values can refer to later ones.