### PR TITLE
macro-let for temporary macro definitions

### DIFF
--- a/sibilant/basics.lspy
+++ b/sibilant/basics.lspy
@@ -39,6 +39,13 @@
 	 (macro ,(str name) (function ,name ,formals ,@body)))))))
 
 
+(defmacro defspecial [name formals . body]
+     "Defines a Special instance in the current module"
+
+     `(define-global ,name
+	(special ,(str name) (function ,name ,formals ,@body))))
+
+
 (defmacro defalias [name . body]
   "Defines an Alias Macro in the current module"
   `(define-global ,name
@@ -1090,6 +1097,33 @@
   `(let-gensyms [[_all_ (! get (globals) "__all__" (#list))]]
      (! extend _all_ (#list ,@(map str syms)))
      (setf (global __all__) (sorted (set _all_)))))
+
+
+;; === macro-let ====
+
+;; macro-let needs to be a special, because it compiles all the way
+;; down and doesn't result in an expanded form. If it were a macro, it
+;; wouldn't be able to do this, as a macro always expands into
+;; something.
+(defspecial macro-let [comp source tc]
+  (define-values [called-by [declarations body]] source)
+
+  (define tmp-macros
+    (eval
+     `(#dict
+       ,@(#gen [[macro-name [macro-formals macro-body]]
+		(unpack declarations)]
+
+	    `(',macro-name
+	      ((lambda [M]
+		 (set-attr M _proper ,(proper? macro-formals))
+		 M)
+	       (macro ,(str macro-name)
+		 (function ,macro-name ,macro-formals
+			   ,@macro-body))))))))
+
+  (with [_ (! tmp_compiled comp tmp-macros)]
+	(! compile comp `{,@body} tc None)))
 
 
 ;;

--- a/sibilant/compiler/__init__.py
+++ b/sibilant/compiler/__init__.py
@@ -811,20 +811,12 @@ class SibilantCompiler(PseudopsCompiler, metaclass=ABCMeta):
 
 
     @contextmanager
-    def tmp_compiled(self, tmp_env):
-        self.push_tmp_compiled(tmp_env)
-        yield
-        self.pop_tmp_compiled()
+    def tmp_compiled(self, tmp_env: Mapping):
+        assert isinstance(tmp_env, Mapping)
 
-
-    def push_tmp_compiled(self, tmp_env: Mapping):
-        print("push_tmp_compiled", tmp_env)
         self.env_tmp_compiled.append(tmp_env)
-
-
-    def pop_tmp_compiled(self):
-        off = self.env_tmp_compiled.pop()
-        print("pop_tmp_compiled", off)
+        yield
+        self.env_tmp_compiled.pop()
 
 
     def find_compiled(self, namesym: Symbol):

--- a/sibilant/compiler/__init__.py
+++ b/sibilant/compiler/__init__.py
@@ -331,6 +331,7 @@ class SibilantCompiler(PseudopsCompiler, metaclass=ABCMeta):
         super().__init__(**kwopts)
 
         self.env = None
+        self.env_tmp_compiled = []
 
         self.tco_enabled = tco_enabled
         self.tailcalls = 0
@@ -343,6 +344,7 @@ class SibilantCompiler(PseudopsCompiler, metaclass=ABCMeta):
     def __del__(self):
         super().__del__()
         del self.env
+        del self.env_tmp_compiled
 
 
     def activate(self, environment):
@@ -808,6 +810,23 @@ class SibilantCompiler(PseudopsCompiler, metaclass=ABCMeta):
                                    filename=self.filename)
 
 
+    @contextmanager
+    def tmp_compiled(self, tmp_env):
+        self.push_tmp_compiled(tmp_env)
+        yield
+        self.pop_tmp_compiled()
+
+
+    def push_tmp_compiled(self, tmp_env: Mapping):
+        print("push_tmp_compiled", tmp_env)
+        self.env_tmp_compiled.append(tmp_env)
+
+
+    def pop_tmp_compiled(self):
+        off = self.env_tmp_compiled.pop()
+        print("pop_tmp_compiled", off)
+
+
     def find_compiled(self, namesym: Symbol):
         """
         Search for and return a Compiled instance within the activated
@@ -822,12 +841,11 @@ class SibilantCompiler(PseudopsCompiler, metaclass=ABCMeta):
             # now ... no.
             return None
 
-        # TODO: compiler should keep a local stack of macros defined
-        # via macrolet, and keyd by symbol or gensym (rather than by
-        # str name). If that falls through, then try the module-level
-        # function which only peeks in env and builtins.
-
-        return env_find_compiled(self.env, namesym)
+        for tmp_env in reversed(self.env_tmp_compiled):
+            if namesym in tmp_env:
+                return tmp_env[namesym]
+        else:
+            return env_find_compiled(self.env, namesym)
 
 
 def compile_expression(source_obj, env, filename="<anon>",

--- a/sibilant/lib.py
+++ b/sibilant/lib.py
@@ -258,7 +258,7 @@ class lazygensym(object):
             return True
 
         sym = self._symbol
-        return (sym and (sym is other))
+        return bool(sym and (sym is other))
 
 
     def __ne__(self, other):

--- a/tests/sibilant/basics.lspy
+++ b/tests/sibilant/basics.lspy
@@ -98,6 +98,43 @@
      None)
 
 
+(def class MacroLetTest (TestCase)
+
+     (def function test_simple_macro_let [self]
+
+	  (self.assertEqual
+
+	   (macro-let
+	    [[m1 [a b] `(+ ,a ,b)]
+	     [m2 [a b] `(- ,a ,b)]]
+
+	    (self.assertEqual (m1 10 5) 15)
+	    (self.assertEqual (m2 10 5) 5)
+
+	    (* (m1 10 5) (m2 10 5)))
+
+	   (* 15 5))
+
+	  None)
+
+     (def function test_shadowing_macro_let [self]
+	  (macro-let
+	   [[m1 [a b] `(+ ,a ,b)]]
+
+	   (self.assertEqual (m1 10 5) 15)
+
+	   (macro-let
+	    [[m1 [a b] `(- ,a ,b)]]
+
+	    (self.assertEqual (m1 10 5) 5))
+
+	   (self.assertEqual (m1 10 5) 15))
+
+	  None)
+
+     None)
+
+
 (def class BuildTest [TestCase]
 
      (def function test_build_list [self]

--- a/tests/sibilant/basics.lspy
+++ b/tests/sibilant/basics.lspy
@@ -100,7 +100,8 @@
 
 (def class MacroLetTest (TestCase)
 
-     (def function test_simple_macro_let [self]
+
+     (def function test_simple [self]
 
 	  (self.assertEqual
 
@@ -117,7 +118,8 @@
 
 	  None)
 
-     (def function test_shadowing_macro_let [self]
+
+     (def function test_shadowed [self]
 	  (macro-let
 	   [[m1 [a b] `(+ ,a ,b)]]
 


### PR DESCRIPTION
* sibilant.compiler.SibilantCompiler gains a tmp_compiled context manager
* sibilant.basics gains a defspecial to create a Special
* sibilant.basics gains macro-let special which creates macros which are
  only available during the compile-time of the body element. Syntax is
  similar to the flet and labels macros.
* Macros defined by macro-let are ONLY available at compile-time, not at
  run-time. They do not declare local fast vars.
* unit tests for macro-let

Closes #128