### PR TITLE
has-attr

### DIFF
--- a/sibilant/compiler/__init__.py
+++ b/sibilant/compiler/__init__.py
@@ -464,9 +464,9 @@ class SibilantCompiler(PseudopsCompiler, metaclass=ABCMeta):
             return tcf(self.compile_nil, source_obj, tc, cont)
 
         if not is_proper(source_obj):
-            print("** WUT", self, source_obj, tc, cont)
+            # print("** WUT", self, source_obj, tc, cont)
             msg = "cannot evaluate improper lists as expressions"
-            raise self._err(msg, source_obj)
+            raise self.error(msg, source_obj)
 
         self.pseudop_position_of(source_obj)
 


### PR DESCRIPTION
# Requesting a pull to obriencj:master from obriencj:has-attr
#
# Write a message for this pull request. The first block
# of text is the title and the rest is the description.
#
# Changes:
#
# d64e749 (Christopher O'Brien, 2 minutes ago)
#    I forgot to bind hasattr
#
# 027f571 (Christopher O'Brien, 12 minutes ago)
#    has-attr via patch from ahills