### PR TITLE
Fix #fmt

### DIFF
--- a/sibilant/basics.lspy
+++ b/sibilant/basics.lspy
@@ -194,6 +194,10 @@ license: LGPL v.3
   `(is None ,value))
 
 
+(defmacro zero? [value]
+  `(== 0 ,value))
+
+
 (defun within? [min_i max_i value_i]
   "
   (within? MIN MAX VALUE)
@@ -924,72 +928,20 @@ license: LGPL v.3
 
 
 (let []
-  (def import-from re
-       [compile as: regex] UNICODE VERBOSE)
-
   (def import-from sibilant.parse
-       [default_reader as: reader] source_str)
-
-  (define fmt-re
-    (regex "(
-    (\\n\\r|\\n)
-    |{{
-    |}}
-    |(?:{([^\\(^\\!\\:}]+
-         |\\(.*\\))(\\!.)?([^}]+)?)}
-    )" (bitwise-or UNICODE VERBOSE)))
-
-  (def function parse-source [src-str]
-       (reader.read (source_str src-str "<format string>")))
+       FormatStringReader source_str)
 
   (defmacro #fmt [text . rest]
-    (var [result (#list)]
-	 [offset 0])
-
-    (for-each [f (fmt-re.finditer text)]
-        (define-values [start stop] (f.span))
-	(result.append (item-slice text offset start))
-	(setq offset stop)
-
-	(var [g (f.groups)]
-	     [c (item g 0)])
-
-	(if (contains (#tuple "{{" "}}" "\n" "\n\r") c)
-	    then: (result.append (item c 0))
-	    else:
-	    { (var [expr (parse-source (item g 2))]
-		   [conv (item g 3)]
-		   [fmt (item g 4)])
-
-	      (setq expr
-		    (cond
-		     [(not conv) expr]
-		     [(== "!r" conv)
-		      `(repr ,expr)]
-		     [(== "!s" conv)
-		      `(str ,expr)]
-		     [(== "!a" conv)
-		      `(ascii ,expr)]
-		     [else:
-		      (raise! Exception
-			      (% "bad format conversion %r" conv))]))
-
-	      (when fmt
-		(setq fmt (item-slice fmt 1)))
-
-	      (setq expr
-		    (if fmt
-			then: `(format ,expr ,fmt)
-			else: `(format ,expr)))
-
-	      (result.append expr) }))
-
-    (result.append (item-slice text offset))
+    (var [fsr (FormatStringReader __reader__)]
+	 [src (source_str text "<format string>")]
+	 [result (fsr.read src)])
 
     (if rest
 	then: `(#str ,@result (#fmt ,@rest))
 	else: `(#str ,@result))))
 
+
+;; == defrecord (maybe throw this away)
 
 (defmacro defrecord [name fields]
   `(def class ,name []
@@ -997,6 +949,8 @@ license: LGPL v.3
 	     ,@(iter-each [field (unpack fields)]
 		   `(set-attr self ,field ,field)))))
 
+
+;; == compiler TCO features
 
 (defmacro compiler-tco-disable []
   (try

--- a/sibilant/operators.py
+++ b/sibilant/operators.py
@@ -27,8 +27,9 @@ license: LGPL v.3
 from .compiler import Operator
 
 from .lib import (
-    symbol, pair, nil, is_pair,
-    build_tuple, build_list, build_set, build_dict
+    symbol, pair, nil, is_pair, is_symbol,
+    build_tuple, build_list, build_set, build_dict,
+    cons,
 )
 
 from functools import reduce
@@ -104,11 +105,13 @@ _symbol_not_in = symbol("not-in")
 _symbol_or = symbol("or")
 _symbol_pow = symbol("power")
 _symbol_pow_ = symbol("**")
+_symbol_quote = symbol("quote")
 _symbol_raise = symbol("raise")
 _symbol_rshift = symbol("shift-right")
 _symbol_rshift_ = symbol(">>")
 _symbol_set_item = symbol("set-item")
 _symbol_slice = symbol("slice")
+_symbol_str = symbol("str")
 _symbol_sub = symbol("subtract")
 _symbol_sub_ = symbol("-")
 
@@ -1073,6 +1076,12 @@ def operator_format(code, source, tc=False):
 
     if rest:
         spec, rest = rest
+        if is_pair(spec):
+            a, b = spec
+            if a is _symbol_quote and b and is_symbol(b[0]):
+                spec = str(b[0])
+            else:
+                spec = cons(_symbol_str, spec, nil)
     else:
         spec = None
 

--- a/tests/sibilant/basics.lspy
+++ b/tests/sibilant/basics.lspy
@@ -239,9 +239,9 @@
 	  None)
 
 
-     (def function test_complicated_fmt [self]
+     (def function test_spec_str_fmt [self]
 	  (def function stmt [count food polite]
-	       (#fmt """I want 0x{count:04x} {food!s}"""
+	       (#fmt """I want 0x{count "04x"} {food}"""
 		     """{(if polite ", please" "")}."""))
 
 	  (self.assertEqual "I want 0x0001 tacos, please."
@@ -250,7 +250,54 @@
 	  (self.assertEqual "I want 0x000f pizza."
 			    (stmt 15 'pizza False))
 
-	  None))
+	  None)
+
+
+     (def function test_spec_symbol_fmt [self]
+	  (def function stmt [count food polite]
+	       (#fmt """I want 0x{count '04x} {food}"""
+		     """{(if polite ", please" "")}."""))
+
+	  (self.assertEqual "I want 0x0001 tacos, please."
+			    (stmt 1 'tacos True))
+
+	  (self.assertEqual "I want 0x000f pizza."
+			    (stmt 15 'pizza False))
+
+	  None)
+
+
+     (def function test_issue_212 [self]
+	  (self.assertEqual
+	   (#fmt "{0} {1}")
+	   "0 1")
+
+	  (self.assertEqual
+	   (#fmt "{0} {1} {(+ 1 1)}")
+	   "0 1 2")
+
+	  (self.assertEqual
+	   (#fmt "{0} {1} {(+ 1 1)} {3}")
+	   "0 1 2 3")
+
+	  (self.assertEqual
+	   (#fmt "{0} {1} {(+ 1 1)} {3} {(+ 2 2)}")
+	   "0 1 2 3 4")
+
+	  (self.assertEqual
+	   (#fmt "{0} {1} {(+ 1 1)} {3} {(+ 2 2)} {5}")
+	   "0 1 2 3 4 5")
+
+	  (self.assertEqual
+	   (#fmt "{0} {1} {(+ 1 1)} {3} {(+ 2 2)} {5} {(+ 3 3)}")
+	   "0 1 2 3 4 5 6")
+
+	  (self.assertEqual
+	   (#fmt "{0} {1} {(+ 1 1)} {3} {(+ 2 2)} {5} {(+ 3 3)} {7}")
+	   "0 1 2 3 4 5 6 7")
+
+	  None)
+     ) ; FormatString
 
 
 (def class Compose [TestCase]
@@ -277,7 +324,10 @@
 	  (self.assertEqual col (#list 101 102 204 204.0))
 	  (self.assertIs (type (item col -1)) float)
 	  (self.assertIs (type res) str)
-	  (self.assertEqual res "204.0")))
+	  (self.assertEqual res "204.0")
+
+	  None)
+     ) ; Compose
 
 
 ;;

--- a/tests/sibilant/basics.lspy
+++ b/tests/sibilant/basics.lspy
@@ -213,6 +213,15 @@
      """
 
 
+     (def function test_escaped_fmt [self]
+
+	  (self.assertEqual (#fmt "{{nothing") "{nothing")
+	  (self.assertEqual (#fmt "{{nothing {0}") "{nothing 0")
+	  (self.assertEqual (#fmt "{0} {{nothing") "0 {nothing")
+
+	  None)
+
+
      (def function test_simple_fmt [self]
 	  (def function stmt [count food]
 	       (#fmt """I want {count} {food}."""))


### PR DESCRIPTION
The #fmt macro had some terrible regex-based parsing. Remove that and use some slightly augmented reader parsing instead.

Closes #212 