### PR TITLE
'pass' operator

### DIFF
--- a/sibilant/lib/__init__.py
+++ b/sibilant/lib/__init__.py
@@ -21,7 +21,7 @@ import operator
 from ._types import symbol, keyword, gensym
 from ._types import pair, nil, cons, car, cdr, setcar, setcdr
 from ._types import build_unpack_pair
-from ._types import reapply
+from ._types import reapply, _pass
 from ._types import build_tuple, build_list, build_set, build_dict
 from ._types import values
 from ._types import getderef, setderef, clearderef
@@ -43,7 +43,7 @@ __all__ = (
     "build_proper", "unpack",
     "build_unpack_pair",
 
-    "reapply", "repeatedly", "last", "take",
+    "reapply", "repeatedly", "last", "take", "_pass",
 
     "build_tuple", "build_list", "build_set", "build_dict",
 

--- a/sibilant/lib/_types.c
+++ b/sibilant/lib/_types.c
@@ -162,6 +162,11 @@ static PyObject *m_reapply(PyObject *mod, PyObject *args, PyObject *kwds) {
 }
 
 
+static PyObject *m_pass(PyObject *mod, PyObject *args, PyObject *kwds) {
+  Py_RETURN_NONE;
+}
+
+
 static PyObject *m_build_tuple(PyObject *mod, PyObject *values) {
 
   // checked
@@ -239,6 +244,9 @@ static PyMethodDef methods[] = {
     "reapply(func, data, count) -> result data\n"
     "Calls `data = func(data)` count times (or until an exception is\n"
     "raised), and returns the final data value." },
+
+  { "_pass", (PyCFunction) m_pass, METH_VARARGS|METH_KEYWORDS,
+    "pass(*args, **kwds) -> None\n" },
 
   { "build_tuple", (PyCFunction) m_build_tuple, METH_VARARGS,
     "build_tuple(*args) -> args" },

--- a/sibilant/operators.py
+++ b/sibilant/operators.py
@@ -29,7 +29,7 @@ from .compiler import Operator
 from .lib import (
     symbol, pair, nil, is_pair, is_symbol,
     build_tuple, build_list, build_set, build_dict,
-    cons,
+    cons, _pass,
 )
 
 from functools import reduce
@@ -103,6 +103,7 @@ _symbol_not_eq = symbol("not-eq")
 _symbol_not_eq_ = symbol("!=")
 _symbol_not_in = symbol("not-in")
 _symbol_or = symbol("or")
+_symbol_pass = symbol("pass")
 _symbol_pow = symbol("power")
 _symbol_pow_ = symbol("**")
 _symbol_quote = symbol("quote")
@@ -141,10 +142,26 @@ def operator(namesym, runtime, *aliases):
     return deco
 
 
+# --- oddball pass operator ---
+
+
+@operator(_symbol_pass, _pass)
+def operator_pass(code, source, tc=False):
+    """
+    Evaluates to None.
+    Sub-expressions are not evaluated.
+    """
+
+    code.pseudop_position_of(source)
+    code.pseudop_const(None)
+    return None
+
+
 # --- conditionally reducing operators ---
 
 
 def runtime_and(*vals):
+    # if only `all` didn't coerce to bool we wouldn't need this
     val = True
     for val in vals:
         if not val:
@@ -183,6 +200,7 @@ def operator_and(code, source, tc=False):
 
 
 def runtime_or(*vals):
+    # if only `any` didn't coerce to bool we wouldn't need this
     val = False
     for val in vals:
         if val:


### PR DESCRIPTION
A built-in no-op operator.

* At compile-time, drops all sub-expressions and evaluates to `None`.
* At run-time, accepts `*args` and `**kwds` and returns `None`.