### PR TITLE
Add __len__ to atom types

### DIFF
--- a/sibilant/lib/atom.c
+++ b/sibilant/lib/atom.c
@@ -90,6 +90,12 @@ static PyObject *atom_str(PyObject *self) {
 }
 
 
+static Py_ssize_t atom_len(PyObject *self) {
+  PyObject *name = ATOM_NAME(self);
+  return PyUnicode_GET_LENGTH(name);
+}
+
+
 static void atom_rewrap(PyObject *vals, unaryfunc conv) {
 
   // checked
@@ -98,6 +104,11 @@ static void atom_rewrap(PyObject *vals, unaryfunc conv) {
     PyList_SetItem(vals, index, conv(PyList_GET_ITEM(vals, index)));
   }
 }
+
+
+static PySequenceMethods atom_as_sequence = {
+  .sq_length = atom_len,
+};
 
 
 /* === symbol === */
@@ -212,6 +223,7 @@ PyTypeObject SibSymbolType = {
   .tp_new = symbol_new,
   .tp_dealloc = symbol_dealloc,
 
+  .tp_as_sequence = &atom_as_sequence,
   .tp_repr = atom_repr,
   .tp_str = atom_str,
 };
@@ -424,6 +436,7 @@ PyTypeObject SibKeywordType = {
   .tp_new = keyword_new,
   .tp_dealloc = keyword_dealloc,
 
+  .tp_as_sequence = &atom_as_sequence,
   .tp_repr = atom_repr,
   .tp_str = atom_str,
 };

--- a/tests/types.py
+++ b/tests/types.py
@@ -304,6 +304,16 @@ class SymbolTest(TestCase):
         self.assertNotEqual('x', x)
 
 
+    def test_len(self):
+        empty = symbol('')
+        short = symbol('1')
+        more = symbol('sibilant')
+
+        self.assertEqual(len(empty), len(''))
+        self.assertEqual(len(short), len('1'))
+        self.assertEqual(len(more), len('sibilant'))
+
+
 class KeywordTest(TestCase):
 
     def test_keyword(self):
@@ -402,6 +412,16 @@ class KeywordTest(TestCase):
 
         self.assertNotEqual(x, 'x')
         self.assertNotEqual('x', x)
+
+
+    def test_len(self):
+        empty = keyword('')
+        short = keyword('1')
+        more = keyword('sibilant')
+
+        self.assertEqual(len(empty), len(''))
+        self.assertEqual(len(short), len('1'))
+        self.assertEqual(len(more), len('sibilant'))
 
 
 class BuildUnpackPairTest(TestCase):


### PR DESCRIPTION
Symbols (and gensyms by extension) and keywords respond to len() with
the string length of their name.