### PR TITLE
Fix define-values compiler error

### DIFF
--- a/sibilant/specials.py
+++ b/sibilant/specials.py
@@ -1153,7 +1153,7 @@ def _helper_setq_values(code, bindings, declare):
 
             if is_symbolish(mid):
                 if declare:
-                    code.declare_var(b)
+                    code.declare_var(mid)
                 code.pseudop_set_var(mid)
             else:
                 msg = "start bindings must be symbols, not %r" % mid

--- a/tests/specials.py
+++ b/tests/specials.py
@@ -1255,6 +1255,126 @@ class SpecialSetqValues(TestCase):
         self.assertEqual(env["e"], 8)
 
 
+class SpecialDefineValues(TestCase):
+
+
+    def test_simple_values(self):
+
+        src = """
+        (define-values (a b c) (values 9 8 7))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertEqual(env["a"], 9)
+        self.assertEqual(env["b"], 8)
+        self.assertEqual(env["c"], 7)
+
+        src = """
+        (define-values (a b . c) (values 9 8 7 6 5))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertEqual(env["a"], 9)
+        self.assertEqual(env["b"], 8)
+        self.assertEqual(env["c"], [7, 6, 5])
+
+
+    def test_nested_values(self):
+
+        src = """
+        (define-values (a (b c)) (values 1 (values 2 3)))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertEqual(env["a"], 1)
+        self.assertEqual(env["b"], 2)
+        self.assertEqual(env["c"], 3)
+
+
+        src = """
+        (define-values (a (b c)) '(1 2 . 3))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertEqual(env["a"], 1)
+        self.assertEqual(env["b"], 2)
+        self.assertEqual(env["c"], 3)
+
+
+    def test_star_values(self):
+
+        src = """
+        (define-values (a b *: c) (values 1 2 3 4 5))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertEqual(env["a"], 1)
+        self.assertEqual(env["b"], 2)
+        self.assertEqual(env["c"], [3, 4, 5])
+
+        src = """
+        (define-values (a b *: c) (values 1 2))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertEqual(env["a"], 1)
+        self.assertEqual(env["b"], 2)
+        self.assertEqual(env["c"], [])
+
+        src = """
+        (define-values (a *: b c) (values 1 2 3 4 5))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertEqual(env["a"], 1)
+        self.assertEqual(env["b"], [2, 3, 4])
+        self.assertEqual(env["c"], 5)
+
+        src = """
+        (define-values (*: a b c) (values 1 2 3 4 5))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertEqual(env["a"], [1, 2, 3])
+        self.assertEqual(env["b"], 4)
+        self.assertEqual(env["c"], 5)
+
+        src = """
+        (define-values (*: a b c) (values 1 2))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertEqual(env["a"], [])
+        self.assertEqual(env["b"], 1)
+        self.assertEqual(env["c"], 2)
+
+        src = """
+        (define-values
+          (*: a (b c *: d) e)
+          (values 1 2 3 (values 4 5 6 7) 8))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertEqual(env["a"], [1, 2, 3])
+        self.assertEqual(env["b"], 4)
+        self.assertEqual(env["c"], 5)
+        self.assertEqual(env["d"], [6, 7])
+        self.assertEqual(env["e"], 8)
+
+        src = """
+        (define-values
+          (*: a (b c . d) e)
+          (values 1 2 3 (values 4 5 6 7) 8))
+        """
+        stmt, env = compile_expr(src)
+        res = stmt()
+        self.assertEqual(env["a"], [1, 2, 3])
+        self.assertEqual(env["b"], 4)
+        self.assertEqual(env["c"], 5)
+        self.assertEqual(env["d"], [6, 7])
+        self.assertEqual(env["e"], 8)
+
+
 class SpecialForEach(TestCase):
 
     def test_range(self):


### PR DESCRIPTION
When using `define-values` in some situations, a compiler error is triggered. Example reproducer:

```
(define-values [*: v] (values: 1 2 3))
```
would produce
```
UnboundLocalError: local variable 'b' referenced before assignment
```